### PR TITLE
feat: expand alt text within details element

### DIFF
--- a/src/components/Post.tsx
+++ b/src/components/Post.tsx
@@ -213,13 +213,20 @@ function PostContent({ post }: PostContentProps) {
         />
       )}
       {post.poll != null && <Poll poll={post.poll} />}
-      {post.media.length > 0 && (
+      {post.media.map((medium) => (
         <div>
-          {post.media.map((medium) => (
-            <Medium medium={medium} />
-          ))}
+          <Medium medium={medium} />
+          {medium.description && medium.description.trim() !== "" && (
+            <>
+              <hr />
+              <details>
+                <summary>ALT text details</summary>
+                {medium.description}
+              </details>
+            </>
+          )}
         </div>
-      )}
+      ))}
       {post.quoteTarget != null && (
         <Post
           post={{ ...post.quoteTarget, sharing: null, quoteTarget: null }}


### PR DESCRIPTION
ref: https://github.com/fedify-dev/hollo/issues/99#issuecomment-2661146833

![An expandable details element labeled "ALT text details" is placed below the image.](https://github.com/user-attachments/assets/a1e65ad0-cb98-484a-a95d-f99d187a685e)

![When the details element is opened, the ALT text of the image is displayed.](https://github.com/user-attachments/assets/fd749503-a201-4c50-aaf0-e83948571c82)
