### PR TITLE
Add test configuration file & improve tests in CI

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,18 @@
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/hollo_test
+SECRET_KEY="test_determinist_key_DO_NOT_USE_IN_PRODUCTION"
+
+# LOG_LEVEL=debug
+# LOG_QUERY=true
+
+# Setting ALLOW_PRIVATE_ADDRESS to true disables SSRF (Server-Side Request Forgery) protection
+# Set to true to test in local network
+# Will be replaced by list of allowed IPs once https://github.com/dahlia/fedify/issues/157
+# is implemented.
+ALLOW_PRIVATE_ADDRESS=false
+
+REMOTE_ACTOR_FETCH_POSTS=10
+
+# We actually use fake storage in tests:
+DRIVE_DISK=fs
+FS_ASSET_PATH=tmp/test_storage
+ASSET_URL_BASE="http://hollo.test/"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -78,4 +78,4 @@ jobs:
       - name: Run the database migrations
         run: pnpm run migrate
       - name: Run the tests
-        run: pnpm test
+        run: pnpm test:ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .env
-.env.test
 assets/
 fedify-hollo-*.tgz
 *.jsonl

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prod": "pnpm run migrate && tsx --env-file-if-exists=.env --dns-result-order=ipv6first bin/server.ts",
     "dev": "pnpm run migrate && tsx watch --env-file-if-exists=.env --dns-result-order=ipv6first bin/server.ts",
     "test": "pnpm run migrate:test && tsx --env-file-if-exists=.env.test --test",
+    "test:ci": "drizzle-kit migrate && tsx --test --test-reporter=@reporters/github --test-reporter-destination=stdout",
     "check": "tsc && biome check .",
     "check:ci": "tsc && biome ci --reporter=github .",
     "migrate": "drizzle-kit migrate",
@@ -60,6 +61,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@dotenvx/dotenvx": "^1.37.0",
+    "@reporters/github": "^1.7.2",
     "@types/fluent-ffmpeg": "^2.1.27",
     "@types/markdown-it": "^14.1.2",
     "@types/node": "^22.13.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       '@dotenvx/dotenvx':
         specifier: ^1.37.0
         version: 1.37.0
+      '@reporters/github':
+        specifier: ^1.7.2
+        version: 1.7.2
       '@types/fluent-ffmpeg':
         specifier: ^2.1.27
         version: 2.1.27
@@ -155,6 +158,18 @@ importers:
         version: 5.7.2
 
 packages:
+
+  '@actions/core@1.11.1':
+    resolution: {integrity: sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==}
+
+  '@actions/exec@1.1.1':
+    resolution: {integrity: sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==}
+
+  '@actions/http-client@2.2.3':
+    resolution: {integrity: sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==}
+
+  '@actions/io@1.1.3':
+    resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -1355,6 +1370,9 @@ packages:
   '@prisma/instrumentation@5.22.0':
     resolution: {integrity: sha512-LxccF392NN37ISGxIurUljZSh1YWnphO34V5a0+T7FVQG2u9bhAXRTJpgmQ3483woVhkraQZFF7cbRrpbw/F4Q==}
 
+  '@reporters/github@1.7.2':
+    resolution: {integrity: sha512-8mvTyKUxxDXkNIWfzv3FsHVwjr8JCwVtwidQws2neV6YgrsJW6OwTOBBhd01RKrDMXPxgpMQuFEfN9hRuUZGuA==}
+
   '@sentry/core@8.47.0':
     resolution: {integrity: sha512-iSEJZMe3DOcqBFZQAqgA3NB2lCWBc4Gv5x/SCri/TVg96wAlss4VrUunSI2Mp0J4jJ5nJcJ2ChqHSBAU48k3FA==}
     engines: {node: '>=14.18'}
@@ -1966,6 +1984,10 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -2409,6 +2431,10 @@ packages:
     resolution: {integrity: sha512-Rehfb9i5+A/j3ou6vo974JBk9WQiODvqW6j3hWubP2/I5iU49akOWsGfbLJakwmiIYB5jnzz+M8ZaxOsW8/Sfg==}
     hasBin: true
 
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -2438,6 +2464,10 @@ packages:
     resolution: {integrity: sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==}
     engines: {node: '>=18.0.0'}
     hasBin: true
+
+  tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
   typescript@5.7.2:
     resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
@@ -2547,6 +2577,22 @@ packages:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
 
 snapshots:
+
+  '@actions/core@1.11.1':
+    dependencies:
+      '@actions/exec': 1.1.1
+      '@actions/http-client': 2.2.3
+
+  '@actions/exec@1.1.1':
+    dependencies:
+      '@actions/io': 1.1.3
+
+  '@actions/http-client@2.2.3':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 5.28.4
+
+  '@actions/io@1.1.3': {}
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -4269,6 +4315,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@reporters/github@1.7.2':
+    dependencies:
+      '@actions/core': 1.11.1
+      stack-utils: 2.0.6
+
   '@sentry/core@8.47.0': {}
 
   '@sentry/node@8.47.0':
@@ -5098,6 +5149,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.23.1
       '@esbuild/win32-x64': 0.23.1
 
+  escape-string-regexp@2.0.0: {}
+
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
@@ -5514,6 +5567,10 @@ snapshots:
 
   ssrfcheck@1.1.1: {}
 
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -5540,6 +5597,8 @@ snapshots:
       get-tsconfig: 4.8.1
     optionalDependencies:
       fsevents: 2.3.3
+
+  tunnel@0.0.6: {}
 
   typescript@5.7.2: {}
 


### PR DESCRIPTION
- adds a `.env.test` file by default
- changes CI to not load `.env.test` since it uses environment variables (this might change back, still getting familiar with node's test harness)
- adds github reporter for CI tests

I think what we'll want such that `.env.test` is always loaded, but the tricky part is that `DATABASE_URL` that should come from the environment variable in CI. I'm not sure how to get that to work nicely. Probably more dotenvx?