### PR TITLE
Replace HOST with BIND

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,17 +1,23 @@
 DATABASE_URL=postgresql://user:password@localhost:5432/dbname
 SENTRY_DSN=
-HOME_URL=https://example.com/  # optional; if present, the home page will redirect to this URL
 SECRET_KEY=secret_key  # generate a secret key with `openssl rand -base64 32`
+HOME_URL=https://example.com/  # optional; if present, the home page will redirect to this URL
+
 LOG_LEVEL=info
 LOG_QUERY=false
+
 BEHIND_PROXY=false
-LISTEN_PORT=3000
+PORT=3000
+# BIND=localhost
+
 # Setting ALLOW_PRIVATE_ADDRESS to true disables SSRF (Server-Side Request Forgery) protection
 # Set to true to test in local network
 # Will be replaced by list of allowed IPs once https://github.com/dahlia/fedify/issues/157
 # is implemented.
 ALLOW_PRIVATE_ADDRESS=false
+
 REMOTE_ACTOR_FETCH_POSTS=10
+
 DRIVE_DISK=
 ASSET_URL_BASE=
 FS_ASSET_PATH=

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,19 +47,15 @@ jobs:
     env:
       # HOME_URL=https://localhost/  # optional; if present, the home page will redirect to this URL
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/hollo_test
-      # generate a secret key with `openssl rand -base64 32`
-      SECRET_KEY: "4b5Lr8rpzOCH1q3JL47SThetLNjUhEsAvHxio4Zjp9g="
+      SECRET_KEY: "test_determinist_key_DO_NOT_USE_IN_PRODUCTION"
       LOG_LEVEL: debug
       LOG_QUERY: true
 
-      BEHIND_PROXY: false
-      LISTEN_PORT: 3000
-      LISTEN_HOST: localhost
       # Setting ALLOW_PRIVATE_ADDRESS to true disables SSRF (Server-Side Request Forgery) protection
       # Set to true to test in local network
       # Will be replaced by list of allowed IPs once https://github.com/dahlia/fedify/issues/157
       # is implemented.
-      ALLOW_PRIVATE_ADDRESS: true
+      ALLOW_PRIVATE_ADDRESS: false
       DRIVE_DISK: "fs"
       FS_ASSET_PATH: ./tmp/test_storage
     steps:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@ Version 0.6.0
 
 To be released.
 
- -  Added the `HOST` environment variable to specify the host address to
+ -  Added the `BIND` environment variable to specify the host address to
     listen on.  [[#114] by Emelia Smith]
 
  -  The theme color of the profile page is now customizable.  The list of all

--- a/bin/server.ts
+++ b/bin/server.ts
@@ -12,18 +12,20 @@ configureSentry(process.env["SENTRY_DSN"]);
 const BEHIND_PROXY = process.env["BEHIND_PROXY"] === "true";
 
 // biome-ignore lint/complexity/useLiteralKeys: tsc complains about this (TS4111)
-const LISTEN_HOST = process.env["HOST"];
+const BIND = process.env["BIND"];
 
 // biome-ignore lint/complexity/useLiteralKeys: tsc complains about this (TS4111)
-const LISTEN_PORT = Number.parseInt(process.env["PORT"] ?? "3000", 10);
+const PORT = Number.parseInt(process.env["PORT"] ?? "3000", 10);
 
-if (!Number.isInteger(LISTEN_PORT)) {
+if (!Number.isInteger(PORT)) {
   console.error("Invalid PORT: must be an integer");
   process.exit(1);
 }
 
-if (LISTEN_HOST && LISTEN_HOST !== "localhost" && !isIP(LISTEN_HOST)) {
-  console.error("Invalid HOST: must be an IP address, if specified");
+if (BIND && BIND !== "localhost" && !isIP(BIND)) {
+  console.error(
+    "Invalid BIND: must be an IP address or localhost, if specified",
+  );
   process.exit(1);
 }
 
@@ -32,12 +34,13 @@ serve(
     fetch: BEHIND_PROXY
       ? behindProxy(app.fetch.bind(app))
       : app.fetch.bind(app),
-    port: LISTEN_PORT,
-    hostname: LISTEN_HOST ?? "localhost",
+    port: PORT,
+    hostname: BIND,
   },
   (info) => {
     let host = info.address;
-    if (LISTEN_HOST === "localhost") {
+    // We override it here to show localhost instead of what it resolves to:
+    if (BIND === "localhost") {
       host = "localhost";
     } else if (info.family === "IPv6") {
       host = `[${info.address}]`;

--- a/docs/src/content/docs/install/env.mdx
+++ b/docs/src/content/docs/install/env.mdx
@@ -17,11 +17,9 @@ Basic settings
 
 The port number to listen on.  3000 by default.
 
-### `HOST` <Badge text="Optional" /> <Badge text="Unused in Railway" variant="tip" />
+### `BIND` <Badge text="Optional" /> <Badge text="Unused in Railway" variant="tip" />
 
-The host address to listen on.  Must be a valid IP address or `localhost`.
-
-`localhost` by default.
+The address to listen on. Must be a valid IP address or `localhost`.
 
 ### `DATABASE_URL` <Badge text="Unused in Railway" variant="tip" />
 

--- a/docs/src/content/docs/ja/install/env.mdx
+++ b/docs/src/content/docs/ja/install/env.mdx
@@ -18,11 +18,9 @@ Railwayのenvironment variablesメニューから設定できます。
 
 サーバーが受信するポート番号。デフォルトは3000です。
 
-### `HOST` <Badge text="オプション" /> <Badge text="Railwayでは使われない" variant="tip" />
+### `BIND` <Badge text="オプション" /> <Badge text="Railwayでは使われない" variant="tip" />
 
 サーバーが受信するホストアドレス。有効なIPアドレスまたは`localhost`である必要があります。
-
-デフォルトは`localhost`です。
 
 ### `DATABASE_URL` <Badge text="Railwayでは使われない" variant="tip" />
 

--- a/docs/src/content/docs/ja/install/env.mdx
+++ b/docs/src/content/docs/ja/install/env.mdx
@@ -20,7 +20,7 @@ Railwayのenvironment variablesメニューから設定できます。
 
 ### `BIND` <Badge text="オプション" /> <Badge text="Railwayでは使われない" variant="tip" />
 
-サーバーが受信するホストアドレス。有効なIPアドレスまたは`localhost`である必要があります。
+サーバーが受信するアドレス。有効なIPアドレスまたは`localhost`である必要があります。
 
 ### `DATABASE_URL` <Badge text="Railwayでは使われない" variant="tip" />
 

--- a/docs/src/content/docs/ko/install/env.mdx
+++ b/docs/src/content/docs/ko/install/env.mdx
@@ -18,11 +18,9 @@ Railway의 environment variables 메뉴에서 설정할 수 있습니다.
 
 서버가 수신할 포트 번호. 기본값은 3000입니다.
 
-### `HOST` <Badge text="선택" /> <Badge text="Railway에서는 안 쓰임" variant="tip" />
+### `BIND` <Badge text="선택" /> <Badge text="Railway에서는 안 쓰임" variant="tip" />
 
 서버가 수신할 호스트 주소. 유효한 IP 주소나 `localhost`여야 합니다.
-
-기본값은 `localhost`입니다.
 
 ### `DATABASE_URL` <Badge text="Railway에서는 안 쓰임" variant="tip" />
 

--- a/docs/src/content/docs/ko/install/env.mdx
+++ b/docs/src/content/docs/ko/install/env.mdx
@@ -20,7 +20,7 @@ Railway의 environment variables 메뉴에서 설정할 수 있습니다.
 
 ### `BIND` <Badge text="선택" /> <Badge text="Railway에서는 안 쓰임" variant="tip" />
 
-서버가 수신할 호스트 주소. 유효한 IP 주소나 `localhost`여야 합니다.
+서버가 수신할 주소. 유효한 IP 주소나 `localhost`여야 합니다.
 
 ### `DATABASE_URL` <Badge text="Railway에서는 안 쓰임" variant="tip" />
 

--- a/docs/src/content/docs/zh-cn/install/env.mdx
+++ b/docs/src/content/docs/zh-cn/install/env.mdx
@@ -15,11 +15,9 @@ Hollo是通过环境变量进行配置的。你可以在项目根目录的 *.env
 
 服务器监听的端口号。默认为3000。
 
-### `HOST` <Badge text="可选" /> <Badge text="Railway中未使用" variant="tip" />
+### `BIND` <Badge text="可选" /> <Badge text="Railway中未使用" variant="tip" />
 
 服务器监听的主机地址。必须是有效的IP地址或`localhost`。
-
-默认是`localhost`。
 
 ### `DATABASE_URL` <Badge text="Railway中未使用" variant="tip" />
 

--- a/docs/src/content/docs/zh-cn/install/env.mdx
+++ b/docs/src/content/docs/zh-cn/install/env.mdx
@@ -17,7 +17,7 @@ Hollo是通过环境变量进行配置的。你可以在项目根目录的 *.env
 
 ### `BIND` <Badge text="可选" /> <Badge text="Railway中未使用" variant="tip" />
 
-服务器监听的主机地址。必须是有效的IP地址或`localhost`。
+服务器监听的地址。必须是有效的IP地址或`localhost`。
 
 ### `DATABASE_URL` <Badge text="Railway中未使用" variant="tip" />
 


### PR DESCRIPTION
This fixes the issue with the container not listening on all interfaces by default (was a breaking change in #114), now BIND will only be used if it's set, otherwise it is `undefined` which means "listen on all interfaces")