### PR TITLE
Refactor OAuth logic for improved testability

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,8 +1,8 @@
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/hollo_test
 SECRET_KEY="test_determinist_key_DO_NOT_USE_IN_PRODUCTION"
 
-LOG_LEVEL=debug
-LOG_QUERY=true
+# LOG_LEVEL=debug
+# LOG_QUERY=true
 
 # Setting ALLOW_PRIVATE_ADDRESS to true disables SSRF (Server-Side Request Forgery) protection
 # Set to true to test in local network

--- a/bin/routes.ts
+++ b/bin/routes.ts
@@ -1,0 +1,6 @@
+import { showRoutes } from "hono/dev";
+import app from "../src/index";
+
+showRoutes(app, {
+  colorize: true,
+});

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "prod": "pnpm run migrate && tsx --env-file-if-exists=.env --dns-result-order=ipv6first bin/server.ts",
     "dev": "pnpm run migrate && tsx watch --env-file-if-exists=.env --dns-result-order=ipv6first bin/server.ts",
+    "list:routes": "tsx --env-file-if-exists=.env bin/routes.ts",
     "test": "pnpm run migrate:test && tsx --env-file-if-exists=.env.test --test",
     "test:ci": "tsx --test --test-reporter=@reporters/github --test-reporter-destination=stdout --test-reporter=spec --test-reporter-destination=stdout",
     "check": "tsc && biome check .",

--- a/src/api/v1/accounts.test.ts
+++ b/src/api/v1/accounts.test.ts
@@ -9,11 +9,10 @@ import {
 } from "../../../tests/helpers/oauth";
 
 import app from "../../index";
-import type * as Schema from "../../schema";
 
 describe("/api/v1/accounts/", () => {
-  let client: Schema.Application;
-  let account: Schema.Account;
+  let client: Awaited<ReturnType<typeof createOAuthApplication>>;
+  let account: Awaited<ReturnType<typeof createAccount>>;
 
   beforeEach(async () => {
     account = await createAccount();

--- a/src/api/v1/accounts.test.ts
+++ b/src/api/v1/accounts.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, it } from "node:test";
+import type { TestContext } from "node:test";
+
+import { cleanDatabase } from "../../../tests/helpers";
+import {
+  createAccount,
+  createOAuthApplication,
+  getAccessToken,
+} from "../../../tests/helpers/oauth";
+
+import app from "../../index";
+import type * as Schema from "../../schema";
+
+describe("/api/v1/accounts/", () => {
+  let client: Schema.Application;
+  let account: Schema.Account;
+
+  beforeEach(async () => {
+    account = await createAccount();
+    client = await createOAuthApplication({
+      scopes: ["read:accounts", "write"],
+    });
+  });
+
+  afterEach(async () => {
+    await cleanDatabase();
+  });
+
+  describe("verify_credentials", () => {
+    it("Successfully returns the current accounts profile with a valid access token", async (t: TestContext) => {
+      t.plan(7);
+
+      const accessToken = await getAccessToken(client, account, [
+        "read:accounts",
+      ]);
+
+      const response = await app.request(
+        "/api/v1/accounts/verify_credentials",
+        {
+          method: "GET",
+          headers: {
+            Authorization: accessToken.authorizationHeader,
+          },
+        },
+      );
+
+      t.assert.equal(response.status, 200);
+      t.assert.equal(response.headers.get("content-type"), "application/json");
+      t.assert.equal(response.headers.get("access-control-allow-origin"), "*");
+
+      const credentialAccount = await response.json();
+
+      t.assert.equal(typeof credentialAccount, "object");
+      t.assert.equal(credentialAccount.id, account.id);
+      t.assert.equal(credentialAccount.username, "hollo");
+      t.assert.equal(credentialAccount.acct, "hollo@hollo.test");
+    });
+
+    it("does not return the account when an invalid scope is used", async (t: TestContext) => {
+      t.plan(4);
+
+      const accessToken = await getAccessToken(client, account, ["write"]);
+
+      const response = await app.request(
+        "/api/v1/accounts/verify_credentials",
+        {
+          method: "GET",
+          headers: {
+            Authorization: accessToken.authorizationHeader,
+          },
+        },
+      );
+
+      t.assert.equal(response.status, 403);
+      t.assert.equal(response.headers.get("content-type"), "application/json");
+      t.assert.equal(response.headers.get("access-control-allow-origin"), "*");
+
+      const error = await response.json();
+
+      t.assert.deepStrictEqual(error, {
+        error: "insufficient_scope",
+      });
+    });
+
+    it("does not return the account when no access token is used", async (t: TestContext) => {
+      t.plan(4);
+
+      const response = await app.request(
+        "/api/v1/accounts/verify_credentials",
+        {
+          method: "GET",
+        },
+      );
+
+      t.assert.equal(response.status, 401);
+      t.assert.equal(response.headers.get("content-type"), "application/json");
+      t.assert.equal(response.headers.get("access-control-allow-origin"), "*");
+
+      const error = await response.json();
+
+      t.assert.deepStrictEqual(error, {
+        error: "unauthorized",
+      });
+    });
+  });
+});

--- a/src/api/v1/accounts.ts
+++ b/src/api/v1/accounts.ts
@@ -36,7 +36,11 @@ import {
   persistAccountPosts,
   unfollowAccount,
 } from "../../federation/account";
-import { type Variables, scopeRequired, tokenRequired } from "../../oauth";
+import {
+  type Variables,
+  scopeRequired,
+  tokenRequired,
+} from "../../oauth/middleware";
 import {
   type Account,
   type AccountOwner,

--- a/src/api/v1/apps.ts
+++ b/src/api/v1/apps.ts
@@ -3,7 +3,7 @@ import { getLogger } from "@logtape/logtape";
 import { Hono } from "hono";
 import { z } from "zod";
 import { db } from "../../db";
-import { type Variables, tokenRequired } from "../../oauth";
+import { type Variables, tokenRequired } from "../../oauth/middleware";
 import {
   type NewApplication,
   type Scope,

--- a/src/api/v1/featured_tags.ts
+++ b/src/api/v1/featured_tags.ts
@@ -13,7 +13,11 @@ import { Hono } from "hono";
 import { z } from "zod";
 import db from "../../db";
 import { serializeFeaturedTag } from "../../entities/tag";
-import { type Variables, scopeRequired, tokenRequired } from "../../oauth";
+import {
+  type Variables,
+  scopeRequired,
+  tokenRequired,
+} from "../../oauth/middleware";
 import type * as schema from "../../schema";
 import { featuredTags, posts } from "../../schema";
 import { type Uuid, isUuid, uuidv7 } from "../../uuid";

--- a/src/api/v1/follow_requests.ts
+++ b/src/api/v1/follow_requests.ts
@@ -9,7 +9,11 @@ import {
 } from "../../entities/account";
 import { federation } from "../../federation";
 import { updateAccountStats } from "../../federation/account";
-import { type Variables, scopeRequired, tokenRequired } from "../../oauth";
+import {
+  type Variables,
+  scopeRequired,
+  tokenRequired,
+} from "../../oauth/middleware";
 import { accounts, blocks, follows, mutes } from "../../schema";
 import { isUuid } from "../../uuid";
 

--- a/src/api/v1/index.ts
+++ b/src/api/v1/index.ts
@@ -7,7 +7,11 @@ import { db } from "../../db";
 import { serializeAccount } from "../../entities/account";
 import { getPostRelations, serializePost } from "../../entities/status";
 import { serializeTag } from "../../entities/tag";
-import { type Variables, scopeRequired, tokenRequired } from "../../oauth";
+import {
+  type Variables,
+  scopeRequired,
+  tokenRequired,
+} from "../../oauth/middleware";
 import {
   accounts as accountsTable,
   blocks,

--- a/src/api/v1/lists.ts
+++ b/src/api/v1/lists.ts
@@ -5,7 +5,11 @@ import { z } from "zod";
 import { db } from "../../db";
 import { serializeAccount } from "../../entities/account";
 import { serializeList } from "../../entities/list";
-import { type Variables, scopeRequired, tokenRequired } from "../../oauth";
+import {
+  type Variables,
+  scopeRequired,
+  tokenRequired,
+} from "../../oauth/middleware";
 import { listMembers, lists } from "../../schema";
 import { isUuid, uuid, uuidv7 } from "../../uuid";
 

--- a/src/api/v1/markers.ts
+++ b/src/api/v1/markers.ts
@@ -4,7 +4,11 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { db } from "../../db";
 import { serializeMarkers } from "../../entities/marker";
-import { type Variables, scopeRequired, tokenRequired } from "../../oauth";
+import {
+  type Variables,
+  scopeRequired,
+  tokenRequired,
+} from "../../oauth/middleware";
 import { type MarkerType, type NewMarker, markers } from "../../schema";
 
 const app = new Hono<{ Variables: Variables }>();

--- a/src/api/v1/media.ts
+++ b/src/api/v1/media.ts
@@ -5,7 +5,11 @@ import sharp from "sharp";
 import { db } from "../../db";
 import { serializeMedium } from "../../entities/medium";
 import { makeVideoScreenshot, uploadThumbnail } from "../../media";
-import { type Variables, scopeRequired, tokenRequired } from "../../oauth";
+import {
+  type Variables,
+  scopeRequired,
+  tokenRequired,
+} from "../../oauth/middleware";
 import { media } from "../../schema";
 import { drive } from "../../storage";
 import { isUuid, uuidv7 } from "../../uuid";

--- a/src/api/v1/notifications.ts
+++ b/src/api/v1/notifications.ts
@@ -23,7 +23,11 @@ import {
 } from "../../entities/account";
 import { serializeReaction } from "../../entities/emoji";
 import { getPostRelations, serializePost } from "../../entities/status";
-import { type Variables, scopeRequired, tokenRequired } from "../../oauth";
+import {
+  type Variables,
+  scopeRequired,
+  tokenRequired,
+} from "../../oauth/middleware";
 import {
   accounts,
   blocks,

--- a/src/api/v1/polls.ts
+++ b/src/api/v1/polls.ts
@@ -7,7 +7,11 @@ import { db } from "../../db";
 import { serializePoll } from "../../entities/poll";
 import { federation } from "../../federation";
 import { toUpdate } from "../../federation/post";
-import { type Variables, scopeRequired, tokenRequired } from "../../oauth";
+import {
+  type Variables,
+  scopeRequired,
+  tokenRequired,
+} from "../../oauth/middleware";
 import { pollOptions, pollVotes, polls } from "../../schema";
 import { isUuid } from "../../uuid";
 

--- a/src/api/v1/reports.ts
+++ b/src/api/v1/reports.ts
@@ -6,7 +6,11 @@ import { z } from "zod";
 import { db } from "../../db";
 import { serializeReport } from "../../entities/report";
 import federation from "../../federation";
-import { type Variables, scopeRequired, tokenRequired } from "../../oauth";
+import {
+  type Variables,
+  scopeRequired,
+  tokenRequired,
+} from "../../oauth/middleware";
 import {
   type Post,
   type Report,

--- a/src/api/v1/statuses.ts
+++ b/src/api/v1/statuses.ts
@@ -40,7 +40,11 @@ import {
   toUpdate,
 } from "../../federation/post";
 import { appendPostToTimelines } from "../../federation/timeline";
-import { type Variables, scopeRequired, tokenRequired } from "../../oauth";
+import {
+  type Variables,
+  scopeRequired,
+  tokenRequired,
+} from "../../oauth/middleware";
 import { type PreviewCard, fetchPreviewCard } from "../../previewcard";
 import {
   type Like,

--- a/src/api/v1/tags.ts
+++ b/src/api/v1/tags.ts
@@ -2,7 +2,11 @@ import { sql } from "drizzle-orm";
 import { Hono } from "hono";
 import { db } from "../../db";
 import { serializeTag } from "../../entities/tag";
-import { type Variables, scopeRequired, tokenRequired } from "../../oauth";
+import {
+  type Variables,
+  scopeRequired,
+  tokenRequired,
+} from "../../oauth/middleware";
 import { accountOwners } from "../../schema";
 
 const app = new Hono<{ Variables: Variables }>();

--- a/src/api/v1/timelines.ts
+++ b/src/api/v1/timelines.ts
@@ -21,7 +21,11 @@ import {
   TIMELINE_INBOXES,
   TIMELINE_INBOX_LIMIT,
 } from "../../federation/timeline";
-import { type Variables, scopeRequired, tokenRequired } from "../../oauth";
+import {
+  type Variables,
+  scopeRequired,
+  tokenRequired,
+} from "../../oauth/middleware";
 import {
   accountOwners,
   blocks,

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -16,7 +16,11 @@ import { getPostRelations, serializePost } from "../../entities/status";
 import { federation } from "../../federation";
 import { persistAccount } from "../../federation/account";
 import { persistPost } from "../../federation/post";
-import { type Variables, scopeRequired, tokenRequired } from "../../oauth";
+import {
+  type Variables,
+  scopeRequired,
+  tokenRequired,
+} from "../../oauth/middleware";
 import { type Account, accounts, posts } from "../../schema";
 import { uuid } from "../../uuid";
 import { postMedia } from "../v1/media";

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,16 @@
+const SECRET_KEY_MINIMUM_LENGTH = 44;
+
+// biome-ignore lint/complexity/useLiteralKeys: tsc complains about this (TS4111)
+const secretKey = process.env["SECRET_KEY"];
+
+if (typeof secretKey !== "string") {
+  throw new Error("SECRET_KEY is required");
+}
+
+if (secretKey.length < SECRET_KEY_MINIMUM_LENGTH) {
+  throw new Error(
+    `SECRET_KEY is too short, received: ${secretKey.length}, expected: ${SECRET_KEY_MINIMUM_LENGTH}`,
+  );
+}
+
+export const SECRET_KEY = secretKey;

--- a/src/login.ts
+++ b/src/login.ts
@@ -1,10 +1,7 @@
 import { getSignedCookie } from "hono/cookie";
 import { createMiddleware } from "hono/factory";
 import { db } from "./db";
-
-// biome-ignore lint/complexity/useLiteralKeys: tsc complains about this (TS4111)
-const SECRET_KEY = process.env["SECRET_KEY"];
-if (SECRET_KEY == null) throw new Error("SECRET_KEY is required");
+import { SECRET_KEY } from "./env";
 
 export const loginRequired = createMiddleware(async (c, next) => {
   const login = await getSignedCookie(c, SECRET_KEY, "login");

--- a/src/oauth.tsx
+++ b/src/oauth.tsx
@@ -13,6 +13,7 @@ import {
   createClientCredential,
 } from "./oauth/helpers";
 import type { Variables } from "./oauth/middleware";
+import { scopesSchema } from "./oauth/validators";
 import {
   type Account,
   type AccountOwner,
@@ -26,25 +27,6 @@ import { renderCustomEmojis } from "./text";
 import { uuid } from "./uuid";
 
 const app = new Hono<{ Variables: Variables }>();
-
-const scopesSchema = z
-  .string()
-  .trim()
-  .transform((v, ctx) => {
-    const scopes: Scope[] = [];
-    for (const scope of v.split(/\s+/g)) {
-      if (!scopeEnum.enumValues.includes(scope as Scope)) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.invalid_enum_value,
-          options: scopeEnum.enumValues,
-          received: scope,
-        });
-        return z.NEVER;
-      }
-      scopes.push(scope as Scope);
-    }
-    return scopes;
-  });
 
 app.get(
   "/authorize",

--- a/src/oauth.tsx
+++ b/src/oauth.tsx
@@ -8,6 +8,7 @@ import { createMiddleware } from "hono/factory";
 import { z } from "zod";
 import { Layout } from "./components/Layout";
 import { db } from "./db";
+import { SECRET_KEY } from "./env";
 import { loginRequired } from "./login";
 import {
   type AccessToken,
@@ -30,10 +31,6 @@ export type Variables = {
       | null;
   };
 };
-
-// biome-ignore lint/complexity/useLiteralKeys: tsc complains about this (TS4111)
-const SECRET_KEY = process.env["SECRET_KEY"];
-if (SECRET_KEY == null) throw new Error("SECRET_KEY is required");
 
 export const tokenRequired = createMiddleware(async (c, next) => {
   const authorization = c.req.header("Authorization");

--- a/src/oauth/helpers.ts
+++ b/src/oauth/helpers.ts
@@ -1,0 +1,162 @@
+import { base64 } from "@hexagon/base64";
+import { getLogger } from "@logtape/logtape";
+
+import db from "../db";
+import { SECRET_KEY } from "../env";
+import * as schema from "../schema";
+import type { Uuid } from "../uuid";
+
+const logger = getLogger(["hollo", "oauth"]);
+
+export async function createAuthorizationCode(
+  application_id: Uuid,
+  account_id: Uuid,
+  scopes: schema.Scope[],
+): Promise<string> {
+  const code = base64.fromArrayBuffer(
+    crypto.getRandomValues(new Uint8Array(16)).buffer as ArrayBuffer,
+    true,
+  );
+
+  await db.insert(schema.accessTokens).values({
+    accountOwnerId: account_id,
+    code,
+    applicationId: application_id,
+    scopes: scopes,
+  });
+
+  return code;
+}
+
+export type AuthorizationCodeVerification =
+  | { verified: true; code: string }
+  | {
+      verified: false;
+      error_description: string;
+    };
+
+export async function verifyAuthorizationCode(
+  token: string,
+): Promise<AuthorizationCodeVerification> {
+  const values = token.split("^");
+  if (values.length !== 3) {
+    return {
+      verified: false,
+      error_description: "invalid authorization code",
+    };
+  }
+
+  const [signature, created, code] = values;
+  const textEncoder = new TextEncoder();
+  const sig = base64.toArrayBuffer(signature, true);
+
+  try {
+    const secretKey = await crypto.subtle.importKey(
+      "raw",
+      textEncoder.encode(SECRET_KEY),
+      { name: "HMAC", hash: "SHA-256" },
+      false,
+      ["verify"],
+    );
+
+    const verified = await crypto.subtle.verify(
+      { name: "HMAC", hash: "SHA-256" },
+      secretKey,
+      sig,
+      textEncoder.encode(`${created}^${code}`),
+    );
+
+    if (!verified) {
+      return {
+        verified: false,
+        error_description: "invalid authorization code",
+      };
+    }
+
+    return { verified: true, code: code };
+  } catch (err) {
+    logger.error("Error verifying authorization code", { error: err });
+
+    return {
+      verified: false,
+      error_description: "invalid authorization code",
+    };
+  }
+}
+
+export type AuthorizationError = {
+  error: string;
+  error_description: string;
+};
+
+export type AccessToken = {
+  token: string;
+  type: "Bearer";
+  scope: string;
+  createdAt: number;
+};
+
+export type AuthorizationGrant = schema.AccessToken;
+
+export async function createAccessToken(
+  authorization_grant: AuthorizationGrant,
+): Promise<AccessToken> {
+  const now = (Date.now() / 1000) | 0;
+  const message = `${now}^${authorization_grant.code}`;
+  const textEncoder = new TextEncoder();
+  const secretKey = await crypto.subtle.importKey(
+    "raw",
+    textEncoder.encode(SECRET_KEY),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+
+  const signature = await crypto.subtle.sign(
+    "HMAC",
+    secretKey,
+    textEncoder.encode(message),
+  );
+
+  return {
+    token: `${base64.fromArrayBuffer(signature, true)}^${message}`,
+    type: "Bearer",
+    scope: authorization_grant.scopes.join(" "),
+    createdAt: now,
+  };
+}
+
+export async function createClientCredential(
+  application: schema.Application,
+  scopes?: schema.Scope[],
+): Promise<AccessToken> {
+  const code = base64.fromArrayBuffer(
+    crypto.getRandomValues(new Uint8Array(16)).buffer as ArrayBuffer,
+    true,
+  );
+
+  const result = await db
+    .insert(schema.accessTokens)
+    .values({
+      code,
+      applicationId: application.id,
+      scopes: scopes ?? application.scopes,
+      grant_type: "client_credentials",
+    })
+    .returning();
+
+  // This would only happen if by some amazing luck we managed to generate two
+  // of the exact same `code` values:
+  if (result.length !== 1) {
+    throw new Error(
+      "We were unable to create a client credential access token at this time.",
+    );
+  }
+
+  return {
+    token: result[0].code,
+    type: "Bearer",
+    scope: result[0].scopes.join(" "),
+    createdAt: (+result[0].created / 1000) | 0,
+  };
+}

--- a/src/oauth/middleware.ts
+++ b/src/oauth/middleware.ts
@@ -1,0 +1,90 @@
+import { eq } from "drizzle-orm";
+import { createMiddleware } from "hono/factory";
+import db from "../db.ts";
+import {
+  type AccessToken,
+  type Account,
+  type AccountOwner,
+  type Application,
+  type Scope,
+  accessTokens,
+} from "../schema.ts";
+
+import { verifyAuthorizationCode } from "./helpers.ts";
+
+export type Variables = {
+  token: AccessToken & {
+    application: Application;
+    accountOwner:
+      | (AccountOwner & { account: Account & { successor: Account | null } })
+      | null;
+  };
+};
+
+export const tokenRequired = createMiddleware(async (c, next) => {
+  const authorization = c.req.header("Authorization");
+  if (authorization == null) return c.json({ error: "unauthorized" }, 401);
+  const match = /^(?:bearer|token)\s+(.+)$/i.exec(authorization);
+  if (match == null) return c.json({ error: "unauthorized" }, 401);
+  const token = match[1];
+
+  let tokenCode: string;
+  if (token.includes("^")) {
+    const result = await verifyAuthorizationCode(token);
+
+    if (!result.verified) {
+      return c.json(
+        {
+          error: "invalid_token",
+          error_description: result.error_description,
+        },
+        401,
+      );
+    }
+
+    tokenCode = result.code;
+  } else {
+    // client credentials
+    tokenCode = token;
+  }
+
+  const accessToken = await db.query.accessTokens.findFirst({
+    where: eq(accessTokens.code, tokenCode),
+    with: {
+      accountOwner: { with: { account: { with: { successor: true } } } },
+      application: true,
+    },
+  });
+
+  if (accessToken == null) {
+    return c.json({ error: "invalid_token" }, 401);
+  }
+
+  c.set("token", accessToken);
+  await next();
+});
+
+export function scopeRequired(scopes: Scope[]) {
+  return createMiddleware(async (c, next) => {
+    const token = c.get("token");
+    if (
+      !scopes.some(
+        (s) =>
+          token.scopes.includes(s) ||
+          token.scopes.includes(s.replace(/:[^:]+$/, "")) ||
+          ([
+            "read:blocks",
+            "write:blocks",
+            "read:follows",
+            "write:follows",
+            "read:mutes",
+            "write:mutes",
+          ].includes(s) &&
+            token.scopes.includes("follow")),
+      )
+    ) {
+      return c.json({ error: "insufficient_scope" }, 403);
+    }
+    await next();
+  });
+}

--- a/src/oauth/validators.ts
+++ b/src/oauth/validators.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { type Scope, scopeEnum } from "../schema";
+
+export const scopesSchema = z
+  .string()
+  .trim()
+  .transform((v, ctx) => {
+    const scopes: Scope[] = [];
+    for (const scope of v.split(/\s+/g)) {
+      if (!scopeEnum.enumValues.includes(scope as Scope)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.invalid_enum_value,
+          options: scopeEnum.enumValues,
+          received: scope,
+        });
+        return z.NEVER;
+      }
+      scopes.push(scope as Scope);
+    }
+    return scopes;
+  });

--- a/src/pages/emojis.test.ts
+++ b/src/pages/emojis.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, it } from "node:test";
 import type { TestContext } from "node:test";
 
-import { getFixtureFile, getLoginCookie } from "../../tests/helpers";
+import { getFixtureFile } from "../../tests/helpers";
+import { getLoginCookie } from "../../tests/helpers/web";
 
 import db from "../db";
 import { customEmojis } from "../schema";

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -2,10 +2,8 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { after, before } from "node:test";
 import { sql } from "drizzle-orm";
-import { serializeSigned } from "hono/utils/cookie";
 
 import db from "../src/db";
-import { SECRET_KEY } from "../src/env";
 import { drive } from "../src/storage";
 
 const fixtureFiles = join(import.meta.dirname, "fixtures", "files");
@@ -19,13 +17,6 @@ export async function getFixtureFile(
 
   return new File([data], name, {
     type,
-  });
-}
-
-export async function getLoginCookie() {
-  // Same logic as in src/pages/login.tsx
-  return serializeSigned("login", new Date().toISOString(), SECRET_KEY!, {
-    path: "/",
   });
 }
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -5,6 +5,7 @@ import { sql } from "drizzle-orm";
 import { serializeSigned } from "hono/utils/cookie";
 
 import db from "../src/db";
+import { SECRET_KEY } from "../src/env";
 import { drive } from "../src/storage";
 
 const fixtureFiles = join(import.meta.dirname, "fixtures", "files");
@@ -20,9 +21,6 @@ export async function getFixtureFile(
     type,
   });
 }
-
-// biome-ignore lint/complexity/useLiteralKeys: tsc complains about this (TS4111)
-const SECRET_KEY = process.env["SECRET_KEY"];
 
 export async function getLoginCookie() {
   // Same logic as in src/pages/login.tsx

--- a/tests/helpers/oauth.ts
+++ b/tests/helpers/oauth.ts
@@ -1,0 +1,124 @@
+import { exportJwk, generateCryptoKeyPair } from "@fedify/fedify";
+import { base64 } from "@hexagon/base64";
+import { eq } from "drizzle-orm";
+
+import db from "../../src/db";
+import * as Schema from "../../src/schema";
+
+import {
+  createAccessToken,
+  createAuthorizationCode,
+} from "../../src/oauth/helpers";
+
+export async function createAccount() {
+  const [account] = await db.transaction(async (tx) => {
+    await tx
+      .insert(Schema.instances)
+      .values({
+        host: "http://hollo.test",
+        software: "hollo",
+        softwareVersion: null,
+      })
+      .onConflictDoNothing();
+    const account = await tx
+      .insert(Schema.accounts)
+      .values({
+        id: crypto.randomUUID(),
+        iri: "http://hollo.test/@hollo",
+        instanceHost: "http://hollo.test",
+        type: "Person",
+        name: "Hollo Test",
+        emojis: {},
+        handle: "@hollo@hollo.test",
+        bioHtml: "",
+        url: "https://hollo.test/@hollo",
+        protected: false,
+        inboxUrl: "https://hollo.test/@hollo/inbox",
+        followersUrl: "https://hollo.test/@hollo/followers",
+        sharedInboxUrl: "https://hollo.test/inbox",
+        featuredUrl: "https://hollo.test/@hollo/pinned",
+        published: new Date(),
+      })
+      .returning();
+
+    const rsaKeyPair = await generateCryptoKeyPair("RSASSA-PKCS1-v1_5");
+    const ed25519KeyPair = await generateCryptoKeyPair("Ed25519");
+
+    const owner = await tx
+      .insert(Schema.accountOwners)
+      .values({
+        id: account[0].id,
+        handle: "hollo",
+        rsaPrivateKeyJwk: await exportJwk(rsaKeyPair.privateKey),
+        rsaPublicKeyJwk: await exportJwk(rsaKeyPair.publicKey),
+        ed25519PrivateKeyJwk: await exportJwk(ed25519KeyPair.privateKey),
+        ed25519PublicKeyJwk: await exportJwk(ed25519KeyPair.publicKey),
+        bio: "",
+        language: "en",
+        visibility: "public",
+        themeColor: "amber",
+        discoverable: false,
+      })
+      .returning();
+
+    return [account[0], owner[0]];
+  });
+
+  return account;
+}
+
+export type OAuthApplicationOptions = {
+  scopes?: Schema.Scope[];
+  redirectUris?: string[];
+};
+
+export async function createOAuthApplication(
+  options: OAuthApplicationOptions = {},
+): Promise<Schema.Application> {
+  const clientId = base64.fromArrayBuffer(
+    crypto.getRandomValues(new Uint8Array(16)).buffer as ArrayBuffer,
+    true,
+  );
+  const clientSecret = base64.fromArrayBuffer(
+    crypto.getRandomValues(new Uint8Array(32)).buffer as ArrayBuffer,
+    true,
+  );
+
+  const app = await db
+    .insert(Schema.applications)
+    .values({
+      id: crypto.randomUUID(),
+      name: "Test Application",
+      redirectUris: options.redirectUris ?? [],
+      scopes: options.scopes ?? [],
+      website: "",
+      clientId,
+      clientSecret,
+    } satisfies Schema.NewApplication)
+    .returning();
+
+  return app[0];
+}
+
+export async function getAccessToken(
+  client: Schema.Application,
+  account: Schema.Account,
+  scopes: Schema.Scope[] = [],
+) {
+  const code = await createAuthorizationCode(client.id, account.id, scopes);
+
+  const authorizationGrant = await db.query.accessTokens.findFirst({
+    where: eq(Schema.accessTokens.code, code),
+    with: {
+      accountOwner: { with: { account: { with: { successor: true } } } },
+      application: true,
+    },
+  });
+
+  const accessToken = await createAccessToken(authorizationGrant!);
+
+  return {
+    authorizationHeader: `${accessToken.type} ${accessToken.token}`,
+    scopes: accessToken.scope.split(" "),
+  };
+}

--- a/tests/helpers/web.ts
+++ b/tests/helpers/web.ts
@@ -1,0 +1,9 @@
+import { serializeSigned } from "hono/utils/cookie";
+import { SECRET_KEY } from "../../src/env";
+
+export async function getLoginCookie() {
+  // Same logic as in src/pages/login.tsx
+  return serializeSigned("login", new Date().toISOString(), SECRET_KEY!, {
+    path: "/",
+  });
+}


### PR DESCRIPTION
## Overview

This pull request aims to improve the ability to write tests for the OAuth routes & middleware by extracting out helpers to create authorization codes, access tokens and client credentials. This allows us to then "mint" a given `Bearer` token or an Authorization Code for use with `/oauth/token`

#### Added
- Test helpers for oauth and api routes
- Test coverage for `GET /api/v1/accounts/verify_credentials`

---

## Minor Breaking Change: SECRET_KEY minimum length

This pull request does have one potentially **minor breaking change**, in that the server will now fail to start up if the `SECRET_KEY` environment variable is shorter than 44 characters. We need a `SECRET_KEY` of sufficient entropy given it is used for cryptographic operations. 

The `.env.sample` and documentation both provided ways to create secure `SECRET_KEY` values, although varied:

```shell
# documentation:
$ openssl rand -hex 32

# .env.sample
$ openssl rand -base64 32
```

---

## Changes to CORS policy

Whilst testing these changes with phanpy, I noticed that the CORS policies were not correctly configured, and did not align with those of Mastodon. Specifically the `.well-known` and `/oauth` routes did not have an accessible CORS policy, which led to client errors.
