### PR TITLE
Display version information on the Hollo Dashboard

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,19 @@
+((nil . ((eglot-server-programs . (((html-mode
+                                     css-mode css-ts-mode
+                                     (js-mode :language-id "javascript")
+                                     (js-ts-mode :language-id "javascript")
+                                     (typescript-mode :language-id "typescript")
+                                     (typescript-ts-mode :language-id "typescript")
+                                     (tsx-ts-mode :language-id "typescriptreact")
+                                     js-json-mode json-mode json-ts-mode jsonc-mode)
+                                    "biome" "lsp-proxy")))
+         (eval . (add-hook 'before-save-hook
+                           (lambda ()
+                             (eglot-format-buffer)
+                             (when (member major-mode '(js-mode
+                                                        js-ts-mode
+                                                        typescript-mode
+                                                        typescript-ts-mode
+                                                        tsx-ts-mode))
+                               (eglot-code-actions (point-min) (point-max)
+                                                   "source.organizeImports.biome" t))))))))

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ fedify-hollo-*.tgz
 *.jsonl
 node_modules/
 tmp/
+mise.local.toml

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,8 @@ To be released.
 
  -  The `scope` parameter is now optional for `POST /oauth/token` endpoint.
 
+ - The current version string is displayed at the bottom of the dashboard page. [[#136], [#137] by RangHo Lee]
+
 [*Colors* section]: https://picocss.com/docs/colors
 [#50]: https://github.com/fedify-dev/hollo/issues/50
 [#110]: https://github.com/fedify-dev/hollo/pull/110
@@ -50,6 +52,8 @@ To be released.
 [#121]: https://github.com/fedify-dev/hollo/pull/121
 [#122]: https://github.com/fedify-dev/hollo/pull/122
 [#126]: https://github.com/fedify-dev/hollo/pull/126
+[#136]: https://github.com/fedify-dev/hollo/issues/136
+[#137]: https://github.com/fedify-dev/hollo/pull/137
 
 
 Version 0.5.5

--- a/src/components/DashboardLayout.tsx
+++ b/src/components/DashboardLayout.tsx
@@ -1,4 +1,5 @@
 import type { PropsWithChildren } from "hono/jsx";
+import metadata from "../../package.json";
 import { Layout, type LayoutProps } from "./Layout";
 
 export type Menu = "accounts" | "emojis" | "federation" | "auth";
@@ -79,6 +80,13 @@ export function DashboardLayout(
         </nav>
       </header>
       {props.children}
+      <footer>
+        <p>
+          <strong>Hollo</strong>
+          <br />
+          Version {metadata.version}
+        </p>
+      </footer>
     </Layout>
   );
 }

--- a/src/public/hollo.css
+++ b/src/public/hollo.css
@@ -9,3 +9,11 @@
   display: inline-block;
   width: auto !important;
 }
+
+footer {
+  margin-block: calc(var(--pico-spacing) * 2);
+  padding-top: calc(var(--pico-spacing) * 2);
+  border-top: var(--pico-border-width) solid var(--pico-muted-border-color);
+  font-size: 0.75rem;
+  text-align: center;
+}


### PR DESCRIPTION
After applying the patch, the dashboard would look like this:

![image](https://github.com/user-attachments/assets/405acc79-4f56-4218-b512-023beeae439d)

Nesting `<header>`, `<main>`, `<footer>` directly under the `<body>` tag should eliminate the need for custom CSS rules, but that would require more significant change in how `DashboarLayout` component is rendered. I figured this is an acceptable solution for now.

Closes #136.