### PR TITLE
fix: Add OPTIONS method to /oauth/token CORS policy to support preflight requests

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -48,7 +48,7 @@ const CorsPolicy = (allowMethods: string[]) =>
 // the /api router adds its own cors policy middleware:
 app.use("/.well-known/*", CorsPolicy(["GET"]));
 app.use("/nodeinfo/*", CorsPolicy(["GET"]));
-app.use("/oauth/token", CorsPolicy(["POST"]));
+app.use("/oauth/token", CorsPolicy(["POST", "OPTIONS"]));
 // Hollo doesn't support token revocation currently:
 // app.use("/oauth/revoke", CorsPolicy(["POST"]));
 app.use("/oauth/userinfo", CorsPolicy(["GET", "POST"]));


### PR DESCRIPTION
This fix addresses the issue where applications could be registered via CORS but authentication would ultimately fail. The preflight request (OPTIONS method) was returning a 404 error, preventing clients from obtaining tokens. By allowing the OPTIONS method, cross-origin authentication flows can complete successfully.