### PR TITLE
Remove Exif metadata before uploading images

### DIFF
--- a/src/api/v1/media.ts
+++ b/src/api/v1/media.ts
@@ -31,7 +31,7 @@ export async function postMedia(c: Context<{ Variables: Variables }>) {
   }
 
   const image = sharp(imageBytes).rotate();
-  const rmMetaImage = await image.toBuffer();
+  const rmMetaImage = await image.keepIccProfile().toBuffer();
   const fileMetadata = await sharp(rmMetaImage).metadata();
   const content = file.type.startsWith("video/") ? new Uint8Array(imageData) : new Uint8Array(rmMetaImage);
   

--- a/src/api/v1/media.ts
+++ b/src/api/v1/media.ts
@@ -29,9 +29,12 @@ export async function postMedia(c: Context<{ Variables: Variables }>) {
   if (file.type.startsWith("video/")) {
     imageBytes = await makeVideoScreenshot(imageData);
   }
-  const image = sharp(imageBytes);
-  const fileMetadata = await image.metadata();
-  const content = new Uint8Array(imageData);
+
+  const image = sharp(imageBytes).rotate();
+  const rmMetaImage = await image.toBuffer();
+  const fileMetadata = await sharp(rmMetaImage).metadata();
+  const content = file.type.startsWith("video/") ? new Uint8Array(imageData) : new Uint8Array(rmMetaImage);
+  
   const extension = mime.getExtension(file.type);
   if (!extension) {
     return c.json({ error: "Unsupported media type" }, 400);


### PR DESCRIPTION
## Summary / 概要

This pull request modifies the image upload logic to:
- Automatically rotate images based on Exif orientation
- Strip all other Exif metadata (including GPS geotags) before saving the image

画像アップロード処理を以下のように改善しました：
- ExifのOrientation（回転）情報に従って画像を正しい向きに自動補正
- その他すべてのExifメタデータ（GPS位置情報など）を削除した状態で保存

## 既存のコードで発生している問題
- スマートフォンで撮影したJPEG等のファイルを添付すると、webpに変換されなかった場合EXIF情報が残ってしまう場合がある
  - 例： https://hl.oyasumi.dev/@ntek/0196f82e-e22a-750f-bff8-aaf4b9a99a4b
    - （私の自宅ではないので、投稿を残してあります。）
![2025-05-24-03-24-chrome_2XophH92tv](https://github.com/user-attachments/assets/72d8b0a3-1aeb-484e-98ee-571e72fd1c70)

---
Please review and let me know if anything needs adjustment.
ご確認のほどよろしくお願いいたします。不備があればご指摘ください。