### PR TITLE
Clarify postMedia processing path

### DIFF
--- a/src/api/v1/media.ts
+++ b/src/api/v1/media.ts
@@ -24,18 +24,18 @@ export async function postMedia(c: Context<{ Variables: Variables }>) {
   }
   const description = form.get("description")?.toString();
   const id = uuidv7();
-  const imageData = new Uint8Array(await file.arrayBuffer());
+  const mediaData = new Uint8Array(await file.arrayBuffer());
   let imageBytes: Uint8Array;
   let image: sharp.Sharp;
   let fileMetadata: sharp.Metadata;
   let content: Uint8Array;
   if (file.type.startsWith("video/")) {
-    imageBytes = await makeVideoScreenshot(imageData);
+    imageBytes = await makeVideoScreenshot(mediaData);
     image = sharp(imageBytes);
     fileMetadata = await image.metadata();
-    content = new Uint8Array(imageData);
+    content = new Uint8Array(mediaData);
   } else if (file.type.startsWith("image/")) {
-    imageBytes = imageData;
+    imageBytes = mediaData;
     image = sharp(imageBytes).rotate();
     const rmMetaImage = await image.keepIccProfile().toBuffer();
     fileMetadata = await sharp(rmMetaImage).metadata();

--- a/src/api/v1/media.ts
+++ b/src/api/v1/media.ts
@@ -25,18 +25,16 @@ export async function postMedia(c: Context<{ Variables: Variables }>) {
   const description = form.get("description")?.toString();
   const id = uuidv7();
   const mediaData = new Uint8Array(await file.arrayBuffer());
-  let imageBytes: Uint8Array;
   let image: sharp.Sharp;
   let fileMetadata: sharp.Metadata;
   let content: Uint8Array;
   if (file.type.startsWith("video/")) {
-    imageBytes = await makeVideoScreenshot(mediaData);
+    const imageBytes: Uint8Array = await makeVideoScreenshot(mediaData);
     image = sharp(imageBytes);
     fileMetadata = await image.metadata();
     content = new Uint8Array(mediaData);
   } else if (file.type.startsWith("image/")) {
-    imageBytes = mediaData;
-    image = sharp(imageBytes).rotate();
+    image = sharp(mediaData).rotate();
     const rmMetaImage = await image.keepIccProfile().toBuffer();
     fileMetadata = await sharp(rmMetaImage).metadata();
     content = new Uint8Array(rmMetaImage);

--- a/src/api/v1/media.ts
+++ b/src/api/v1/media.ts
@@ -33,8 +33,10 @@ export async function postMedia(c: Context<{ Variables: Variables }>) {
   const image = sharp(imageBytes).rotate();
   const rmMetaImage = await image.keepIccProfile().toBuffer();
   const fileMetadata = await sharp(rmMetaImage).metadata();
-  const content = file.type.startsWith("video/") ? new Uint8Array(imageData) : new Uint8Array(rmMetaImage);
-  
+  const content = file.type.startsWith("video/")
+    ? new Uint8Array(imageData)
+    : new Uint8Array(rmMetaImage);
+
   const extension = mime.getExtension(file.type);
   if (!extension) {
     return c.json({ error: "Unsupported media type" }, 400);


### PR DESCRIPTION
### Summary / 概要

This PR addresses the following review feedback from @ThisIsMissEm:
> https://github.com/fedify-dev/hollo/pull/152#discussion_r2105907376

The goal is to clarify the conditional logic used to process uploaded files by separating the image and video handling more explicitly.

---

### Benefits / メリット

- Easier to understand how uploaded content is handled depending on its MIME type
- More maintainable and less error-prone

---

Please review the changes. Feedback welcome as always!
ご確認よろしくお願いします！ご意見ありましたらぜひお寄せください 🙏
