### PR TITLE
Migrate to vitest to improve coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,7 @@ node_modules/
 tmp/
 mise.local.toml
 
+coverage/**
+!coverage/.gitkeep
+
 **/.claude/settings.local.json

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@types/semver": "^7.5.8",
     "@vitest/coverage-v8": "3.1.4",
     "dotenv": "^16.5.0",
+    "timekeeper": "^2.3.1",
     "typescript": "^5.7.2",
     "vitest": "^3.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "prod": "pnpm run migrate && tsx --env-file-if-exists=.env --dns-result-order=ipv6first bin/server.ts",
     "dev": "pnpm run migrate && tsx watch --env-file-if-exists=.env --dns-result-order=ipv6first bin/server.ts",
     "list:routes": "tsx --env-file-if-exists=.env bin/routes.ts",
-    "test": "pnpm run migrate:test && tsx --env-file-if-exists=.env.test --test --test-concurrency=1",
-    "test:ci": "tsx --test --test-reporter=@reporters/github --test-reporter-destination=stdout --test-reporter=spec --test-reporter-destination=stdout --test-concurrency=1",
+    "test": "pnpm run migrate:test && vitest",
+    "test:ci": "vitest",
     "check": "tsc && biome check .",
     "check:ci": "tsc && biome ci --reporter=github .",
-    "check:coverage": "c8 --check-coverage --lines 100 pnpm test -- --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=coverage/tmp/lcov.info",
+    "check:coverage": "pnpm run migrate:test && vitest --coverage",
     "migrate": "drizzle-kit migrate",
     "migrate:test": "dotenvx run -f .env.test -- drizzle-kit migrate",
     "migrate:generate": "drizzle-kit generate",
@@ -69,8 +69,10 @@
     "@types/node": "^22.13.4",
     "@types/qrcode": "^1.5.5",
     "@types/semver": "^7.5.8",
-    "c8": "^10.1.3",
-    "typescript": "^5.7.2"
+    "@vitest/coverage-v8": "3.1.4",
+    "dotenv": "^16.5.0",
+    "typescript": "^5.7.2",
+    "vitest": "^3.1.4"
   },
   "packageManager": "pnpm@9.15.1+sha512.1acb565e6193efbebda772702950469150cf12bcc764262e7587e71d19dc98a423dff9536e57ea44c49bdf790ff694e83c27be5faa23d67e0c033b583be4bfcf"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       dotenv:
         specifier: ^16.5.0
         version: 16.5.0
+      timekeeper:
+        specifier: ^2.3.1
+        version: 2.3.1
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
@@ -2988,6 +2991,9 @@ packages:
   test-exclude@7.0.1:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
     engines: {node: '>=18'}
+
+  timekeeper@2.3.1:
+    resolution: {integrity: sha512-LeQRS7/4JcC0PgdSFnfUiStQEdiuySlCj/5SJ18D+T1n9BoY7PxKFfCwLulpHXoLUFr67HxBddQdEX47lDGx1g==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -6707,6 +6713,8 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 10.4.5
       minimatch: 9.0.5
+
+  timekeeper@2.3.1: {}
 
   tinybench@2.9.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,12 +153,18 @@ importers:
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
-      c8:
-        specifier: ^10.1.3
-        version: 10.1.3
+      '@vitest/coverage-v8':
+        specifier: 3.1.4
+        version: 3.1.4(vitest@3.1.4(@types/node@22.15.3)(tsx@4.19.2))
+      dotenv:
+        specifier: ^16.5.0
+        version: 16.5.0
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
+      vitest:
+        specifier: ^3.1.4
+        version: 3.1.4(@types/node@22.15.3)(tsx@4.19.2)
 
 packages:
 
@@ -173,6 +179,10 @@ packages:
 
   '@actions/io@1.1.3':
     resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -457,6 +467,23 @@ packages:
     resolution: {integrity: sha512-2GPCwlNxeHspoK/Mc8nbk9cBOkSpp3j2SJUQmFnyQK6V/pR6II2oPRyZkMomug1Rc10hqlBHByMecq4zhV2uUw==}
     engines: {node: '>=16.0.0'}
 
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.27.2':
+    resolution: {integrity: sha512-QYLs8299NA7WM/bZAdp+CviYYkVoYXlDW2rzliy3chxd1PQjej7JORuMJDJXJUb9g0TT+B99EwaVLKmX+sPXWw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.27.1':
+    resolution: {integrity: sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==}
+    engines: {node: '>=6.9.0'}
+
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
@@ -563,6 +590,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.25.4':
+    resolution: {integrity: sha512-1VCICWypeQKhVbE9oW/sJaAmjLxhVqacdkvPLEjwlttjfwENRSClS8EjBz0KzRyFSCPDIkuXW34Je/vk7zdB7Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
@@ -577,6 +610,12 @@ packages:
 
   '@esbuild/android-arm64@0.23.1':
     resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.4':
+    resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -599,6 +638,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.25.4':
+    resolution: {integrity: sha512-QNdQEps7DfFwE3hXiU4BZeOV68HHzYwGd0Nthhd3uCkkEKK7/R6MTgM0P7H7FAs5pU/DIWsviMmEGxEoxIZ+ZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.18.20':
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
@@ -613,6 +658,12 @@ packages:
 
   '@esbuild/android-x64@0.23.1':
     resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.4':
+    resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -635,6 +686,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.25.4':
+    resolution: {integrity: sha512-Y1giCfM4nlHDWEfSckMzeWNdQS31BQGs9/rouw6Ub91tkK79aIMTH3q9xHvzH8d0wDru5Ci0kWB8b3up/nl16g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.18.20':
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
@@ -649,6 +706,12 @@ packages:
 
   '@esbuild/darwin-x64@0.23.1':
     resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.4':
+    resolution: {integrity: sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -671,6 +734,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.25.4':
+    resolution: {integrity: sha512-yYq+39NlTRzU2XmoPW4l5Ifpl9fqSk0nAJYM/V/WUGPEFfek1epLHJIkTQM6bBs1swApjO5nWgvr843g6TjxuQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.18.20':
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
@@ -685,6 +754,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.23.1':
     resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.4':
+    resolution: {integrity: sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -707,6 +782,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.25.4':
+    resolution: {integrity: sha512-+89UsQTfXdmjIvZS6nUnOOLoXnkUTB9hR5QAeLrQdzOSWZvNSAXAtcRDHWtqAUtAmv7ZM1WPOOeSxDzzzMogiQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.18.20':
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
@@ -721,6 +802,12 @@ packages:
 
   '@esbuild/linux-arm@0.23.1':
     resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.4':
+    resolution: {integrity: sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -743,6 +830,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.4':
+    resolution: {integrity: sha512-yTEjoapy8UP3rv8dB0ip3AfMpRbyhSN3+hY8mo/i4QXFeDxmiYbEKp3ZRjBKcOP862Ua4b1PDfwlvbuwY7hIGQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.18.20':
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
@@ -757,6 +850,12 @@ packages:
 
   '@esbuild/linux-loong64@0.23.1':
     resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.4':
+    resolution: {integrity: sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -779,6 +878,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.4':
+    resolution: {integrity: sha512-IcvTlF9dtLrfL/M8WgNI/qJYBENP3ekgsHbYUIzEzq5XJzzVEV/fXY9WFPfEEXmu3ck2qJP8LG/p3Q8f7Zc2Xg==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.18.20':
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
@@ -793,6 +898,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.23.1':
     resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.4':
+    resolution: {integrity: sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -815,6 +926,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.4':
+    resolution: {integrity: sha512-i8JUDAufpz9jOzo4yIShCTcXzS07vEgWzyX3NH2G7LEFVgrLEhjwL3ajFE4fZI3I4ZgiM7JH3GQ7ReObROvSUA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.18.20':
     resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
@@ -829,6 +946,12 @@ packages:
 
   '@esbuild/linux-s390x@0.23.1':
     resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.4':
+    resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -851,6 +974,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.4':
+    resolution: {integrity: sha512-6e0cvXwzOnVWJHq+mskP8DNSrKBr1bULBvnFLpc1KY+d+irZSgZ02TGse5FsafKS5jg2e4pbvK6TPXaF/A6+CA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.4':
+    resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.18.20':
     resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
     engines: {node: '>=12'}
@@ -869,8 +1004,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.25.4':
+    resolution: {integrity: sha512-XAg8pIQn5CzhOB8odIcAm42QsOfa98SBeKUdo4xa8OvX8LbMZqEtgeWE9P/Wxt7MlG2QqvjGths+nq48TrUiKw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.23.1':
     resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.25.4':
+    resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -893,6 +1040,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.25.4':
+    resolution: {integrity: sha512-xAGGhyOQ9Otm1Xu8NT1ifGLnA6M3sJxZ6ixylb+vIUVzvvd6GOALpwQrYrtlPouMqd/vSbgehz6HaVk4+7Afhw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/sunos-x64@0.18.20':
     resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
     engines: {node: '>=12'}
@@ -907,6 +1060,12 @@ packages:
 
   '@esbuild/sunos-x64@0.23.1':
     resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.4':
+    resolution: {integrity: sha512-Mw+tzy4pp6wZEK0+Lwr76pWLjrtjmJyUB23tHKqEDP74R3q95luY/bXqXZeYl4NYlvwOqoRKlInQialgCKy67Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -929,6 +1088,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.25.4':
+    resolution: {integrity: sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.18.20':
     resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
     engines: {node: '>=12'}
@@ -947,6 +1112,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.4':
+    resolution: {integrity: sha512-i1sW+1i+oWvQzSgfRcxxG2k4I9n3O9NRqy8U+uugaT2Dy7kLO9Y7wI72haOahxceMX8hZAzgGou1FhndRldxRg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.18.20':
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
@@ -961,6 +1132,12 @@ packages:
 
   '@esbuild/win32-x64@0.23.1':
     resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.4':
+    resolution: {integrity: sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1126,8 +1303,16 @@ packages:
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
 
+  '@jridgewell/gen-mapping@0.3.8':
+    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/set-array@1.2.1':
+    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
 
   '@jridgewell/sourcemap-codec@1.5.0':
@@ -1409,6 +1594,106 @@ packages:
   '@reporters/github@1.7.2':
     resolution: {integrity: sha512-8mvTyKUxxDXkNIWfzv3FsHVwjr8JCwVtwidQws2neV6YgrsJW6OwTOBBhd01RKrDMXPxgpMQuFEfN9hRuUZGuA==}
 
+  '@rollup/rollup-android-arm-eabi@4.41.1':
+    resolution: {integrity: sha512-NELNvyEWZ6R9QMkiytB4/L4zSEaBC03KIXEghptLGLZWJ6VPrL63ooZQCOnlx36aQPGhzuOMwDerC1Eb2VmrLw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.41.1':
+    resolution: {integrity: sha512-DXdQe1BJ6TK47ukAoZLehRHhfKnKg9BjnQYUu9gzhI8Mwa1d2fzxA1aw2JixHVl403bwp1+/o/NhhHtxWJBgEA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.41.1':
+    resolution: {integrity: sha512-5afxvwszzdulsU2w8JKWwY8/sJOLPzf0e1bFuvcW5h9zsEg+RQAojdW0ux2zyYAz7R8HvvzKCjLNJhVq965U7w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.41.1':
+    resolution: {integrity: sha512-egpJACny8QOdHNNMZKf8xY0Is6gIMz+tuqXlusxquWu3F833DcMwmGM7WlvCO9sB3OsPjdC4U0wHw5FabzCGZg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.41.1':
+    resolution: {integrity: sha512-DBVMZH5vbjgRk3r0OzgjS38z+atlupJ7xfKIDJdZZL6sM6wjfDNo64aowcLPKIx7LMQi8vybB56uh1Ftck/Atg==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.41.1':
+    resolution: {integrity: sha512-3FkydeohozEskBxNWEIbPfOE0aqQgB6ttTkJ159uWOFn42VLyfAiyD9UK5mhu+ItWzft60DycIN1Xdgiy8o/SA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.41.1':
+    resolution: {integrity: sha512-wC53ZNDgt0pqx5xCAgNunkTzFE8GTgdZ9EwYGVcg+jEjJdZGtq9xPjDnFgfFozQI/Xm1mh+D9YlYtl+ueswNEg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.41.1':
+    resolution: {integrity: sha512-jwKCca1gbZkZLhLRtsrka5N8sFAaxrGz/7wRJ8Wwvq3jug7toO21vWlViihG85ei7uJTpzbXZRcORotE+xyrLA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.41.1':
+    resolution: {integrity: sha512-g0UBcNknsmmNQ8V2d/zD2P7WWfJKU0F1nu0k5pW4rvdb+BIqMm8ToluW/eeRmxCared5dD76lS04uL4UaNgpNA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.41.1':
+    resolution: {integrity: sha512-XZpeGB5TKEZWzIrj7sXr+BEaSgo/ma/kCgrZgL0oo5qdB1JlTzIYQKel/RmhT6vMAvOdM2teYlAaOGJpJ9lahg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.41.1':
+    resolution: {integrity: sha512-bkCfDJ4qzWfFRCNt5RVV4DOw6KEgFTUZi2r2RuYhGWC8WhCA8lCAJhDeAmrM/fdiAH54m0mA0Vk2FGRPyzI+tw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.41.1':
+    resolution: {integrity: sha512-3mr3Xm+gvMX+/8EKogIZSIEF0WUu0HL9di+YWlJpO8CQBnoLAEL/roTCxuLncEdgcfJcvA4UMOf+2dnjl4Ut1A==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.41.1':
+    resolution: {integrity: sha512-3rwCIh6MQ1LGrvKJitQjZFuQnT2wxfU+ivhNBzmxXTXPllewOF7JR1s2vMX/tWtUYFgphygxjqMl76q4aMotGw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.41.1':
+    resolution: {integrity: sha512-LdIUOb3gvfmpkgFZuccNa2uYiqtgZAz3PTzjuM5bH3nvuy9ty6RGc/Q0+HDFrHrizJGVpjnTZ1yS5TNNjFlklw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.41.1':
+    resolution: {integrity: sha512-oIE6M8WC9ma6xYqjvPhzZYk6NbobIURvP/lEbh7FWplcMO6gn7MM2yHKA1eC/GvYwzNKK/1LYgqzdkZ8YFxR8g==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.41.1':
+    resolution: {integrity: sha512-cWBOvayNvA+SyeQMp79BHPK8ws6sHSsYnK5zDcsC3Hsxr1dgTABKjMnMslPq1DvZIp6uO7kIWhiGwaTdR4Og9A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.41.1':
+    resolution: {integrity: sha512-y5CbN44M+pUCdGDlZFzGGBSKCA4A/J2ZH4edTYSSxFg7ce1Xt3GtydbVKWLlzL+INfFIZAEg1ZV6hh9+QQf9YQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-win32-arm64-msvc@4.41.1':
+    resolution: {integrity: sha512-lZkCxIrjlJlMt1dLO/FbpZbzt6J/A8p4DnqzSa4PWqPEUUUnzXLeki/iyPLfV0BmHItlYgHUqJe+3KiyydmiNQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.41.1':
+    resolution: {integrity: sha512-+psFT9+pIh2iuGsxFYYa/LhS5MFKmuivRsx9iPJWNSGbh2XVEjk90fmpUEjCnILPEPJnikAU6SFDiEUyOv90Pg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.41.1':
+    resolution: {integrity: sha512-Wq2zpapRYLfi4aKxf2Xff0tN+7slj2d4R87WEzqw7ZLsVvO5zwYCIuEGSZYiK41+GlwUo1HiR+GdkLEJnCKTCw==}
+    cpu: [x64]
+    os: [win32]
+
   '@sentry/core@8.47.0':
     resolution: {integrity: sha512-iSEJZMe3DOcqBFZQAqgA3NB2lCWBc4Gv5x/SCri/TVg96wAlss4VrUunSI2Mp0J4jJ5nJcJ2ChqHSBAU48k3FA==}
     engines: {node: '>=14.18'}
@@ -1675,11 +1960,11 @@ packages:
   '@types/connect@3.4.36':
     resolution: {integrity: sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==}
 
+  '@types/estree@1.0.7':
+    resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
+
   '@types/fluent-ffmpeg@2.1.27':
     resolution: {integrity: sha512-QiDWjihpUhriISNoBi2hJBRUUmoj/BMTYcfz+F+ZM9hHWBYABFAE6hjP/TbCZC0GWwlpa3FzvHH9RzFeRusZ7A==}
-
-  '@types/istanbul-lib-coverage@2.0.6':
-    resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
 
   '@types/linkify-it@5.0.0':
     resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
@@ -1723,6 +2008,44 @@ packages:
   '@types/ws@8.5.14':
     resolution: {integrity: sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==}
 
+  '@vitest/coverage-v8@3.1.4':
+    resolution: {integrity: sha512-G4p6OtioySL+hPV7Y6JHlhpsODbJzt1ndwHAFkyk6vVjpK03PFsKnauZIzcd0PrK4zAbc5lc+jeZ+eNGiMA+iw==}
+    peerDependencies:
+      '@vitest/browser': 3.1.4
+      vitest: 3.1.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@3.1.4':
+    resolution: {integrity: sha512-xkD/ljeliyaClDYqHPNCiJ0plY5YIcM0OlRiZizLhlPmpXWpxnGMyTZXOHFhFeG7w9P5PBeL4IdtJ/HeQwTbQA==}
+
+  '@vitest/mocker@3.1.4':
+    resolution: {integrity: sha512-8IJ3CvwtSw/EFXqWFL8aCMu+YyYXG2WUSrQbViOZkWTKTVicVwZ/YiEZDSqD00kX+v/+W+OnxhNWoeVKorHygA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.1.4':
+    resolution: {integrity: sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==}
+
+  '@vitest/runner@3.1.4':
+    resolution: {integrity: sha512-djTeF1/vt985I/wpKVFBMWUlk/I7mb5hmD5oP8K9ACRmVXgKTae3TUOtXAEBfslNKPzUQvnKhNd34nnRSYgLNQ==}
+
+  '@vitest/snapshot@3.1.4':
+    resolution: {integrity: sha512-JPHf68DvuO7vilmvwdPr9TS0SuuIzHvxeaCkxYcCD4jTk67XwL45ZhEHFKIuCm8CYstgI6LZ4XbwD6ANrwMpFg==}
+
+  '@vitest/spy@3.1.4':
+    resolution: {integrity: sha512-Xg1bXhu+vtPXIodYN369M86K8shGLouNjoVI78g8iAq2rFoHFdajNvJJ5A/9bPMFcfQqdaCpOgWKEoMQg/s0Yg==}
+
+  '@vitest/utils@3.1.4':
+    resolution: {integrity: sha512-yriMuO1cfFhmiGc8ataN51+9ooHRuURdfAZfwFd3usWynjzpLslZdYnRegTv32qdgtJTsj15FoeZe2g15fY1gg==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -1764,6 +2087,10 @@ packages:
     resolution: {integrity: sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==}
     engines: {node: '>=12.0.0'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   async@0.2.10:
     resolution: {integrity: sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==}
 
@@ -1793,15 +2120,9 @@ packages:
     resolution: {integrity: sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==}
     engines: {node: '>=6.0.0'}
 
-  c8@10.1.3:
-    resolution: {integrity: sha512-LvcyrOAaOnrrlMpW22n690PUvxiq4Uf9WMhQwNJ9vgagkL/ph1+D4uvjvDA5XCbykrc0sx+ay6pVi9YZ1GnhyA==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      monocart-coverage-reports: ^2
-    peerDependenciesMeta:
-      monocart-coverage-reports:
-        optional: true
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
@@ -1814,8 +2135,16 @@ packages:
     resolution: {integrity: sha512-rRYnn5Elur8RuNHKoJ2b0tgn+pjYxL7BzWom+JZ7NKKn1lt/yGV/tUNwOovxYa9l9VL5hnXQdMc+mENbhJzosQ==}
     engines: {node: '>=18'}
 
+  chai@5.2.0:
+    resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
+    engines: {node: '>=12'}
+
   chardet@2.0.0:
     resolution: {integrity: sha512-xVgPpulCooDjY6zH4m9YW3jbkaBe3FKIAvF5sj5t7aBNsVl2ljIE+xwJ4iNgiDZHFQvNIpjdKdVOQvvk5ZfxbQ==}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -1829,10 +2158,6 @@ packages:
 
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
-
-  cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1854,9 +2179,6 @@ packages:
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
-
-  convert-source-map@2.0.0:
-    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1896,6 +2218,10 @@ packages:
   decamelize@1.2.0:
     resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
     engines: {node: '>=0.10.0'}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   detect-libc@2.0.3:
     resolution: {integrity: sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==}
@@ -2037,6 +2363,9 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-toolkit@1.30.1:
     resolution: {integrity: sha512-ZXflqanzH8BpHkDhFa10bBf6ONDCe84EPUm7SSICGzuuROSluT2ynTPtwn9PcRelMtorCRozSknI/U0MNYp0Uw==}
 
@@ -2060,13 +2389,17 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  escalade@3.2.0:
-    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
-    engines: {node: '>=6'}
+  esbuild@0.25.4:
+    resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -2079,6 +2412,10 @@ packages:
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
+
+  expect-type@1.2.1:
+    resolution: {integrity: sha512-/kP8CAwxzLVEeFrMm4kMmy4CCDlpipyA7MYLVrdJIkV0fYF0UaigQHRsxHiuY/GEea+bh4KSv3TIlgr+2UL6bw==}
+    engines: {node: '>=12.0.0'}
 
   fast-xml-parser@4.4.1:
     resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
@@ -2099,10 +2436,6 @@ packages:
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
-
-  find-up@5.0.0:
-    resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
-    engines: {node: '>=10'}
 
   flattie@1.1.1:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
@@ -2231,6 +2564,10 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
   istanbul-reports@3.1.7:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
     engines: {node: '>=8'}
@@ -2269,9 +2606,8 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
-  locate-path@6.0.0:
-    resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
-    engines: {node: '>=10'}
+  loupe@3.1.3:
+    resolution: {integrity: sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -2279,6 +2615,12 @@ packages:
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  magic-string@0.30.17:
+    resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -2338,6 +2680,11 @@ packages:
   multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   neat-csv@7.0.0:
     resolution: {integrity: sha512-ZmiKZNkdqb6hrBU3lDHm52vWXs6CuFPfw6ZoJZNnY7IIpfA1fxM0UPPi+iQpqQo82qcLbsZPwLkQ1cdrMDtwwA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2385,17 +2732,9 @@ packages:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
 
-  p-limit@3.1.0:
-    resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
-    engines: {node: '>=10'}
-
   p-locate@4.1.0:
     resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
     engines: {node: '>=8'}
-
-  p-locate@5.0.0:
-    resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
-    engines: {node: '>=10'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -2428,6 +2767,13 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.0:
+    resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
+    engines: {node: '>= 14.16'}
+
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
@@ -2438,6 +2784,9 @@ packages:
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@4.0.2:
     resolution: {integrity: sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==}
@@ -2454,6 +2803,10 @@ packages:
   pngjs@5.0.0:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
+
+  postcss@8.5.3:
+    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
@@ -2514,6 +2867,11 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  rollup@4.41.1:
+    resolution: {integrity: sha512-cPmwD3FnFv8rKMBc1MxWCwVQFxwf1JEmSX3iQXrRVVG15zerAIXRjMFVWnd5Q5QvgKF7Aj+5ykXFhUl+QGnyOw==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
@@ -2550,6 +2908,9 @@ packages:
   shimmer@1.2.1:
     resolution: {integrity: sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -2568,6 +2929,10 @@ packages:
     resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
     engines: {node: '>=8.0.0'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
 
@@ -2582,6 +2947,12 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.9.0:
+    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2617,6 +2988,28 @@ packages:
   test-exclude@7.0.1:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
     engines: {node: '>=18'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.14:
+    resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.0.2:
+    resolution: {integrity: sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   truncatise@0.0.8:
     resolution: {integrity: sha512-cXzueh9pzBCsLzhToB4X4gZCb3KYkrsAcBAX97JnazE74HOl3cpBJYEV7nabHeG/6/WXCU5Yujlde/WPBUwnsg==}
@@ -2675,12 +3068,81 @@ packages:
   uuidv7-js@1.1.4:
     resolution: {integrity: sha512-sdPQ05wdM1jaGgSoH0vSc5AqIaT4k2fqYH9Ep/O/Qzfi7Ii9XsfCYh784f1rRv/lJju2j1wdDbzvI53kVkhtHQ==}
 
-  v8-to-istanbul@9.3.0:
-    resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
-    engines: {node: '>=10.12.0'}
-
   varint@6.0.0:
     resolution: {integrity: sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==}
+
+  vite-node@3.1.4:
+    resolution: {integrity: sha512-6enNwYnpyDo4hEgytbmc6mYWHXDHYEn0D1/rw4Q+tnHUGtKTJsn8T1YkX6Q18wI5LCrS8CTYlBaiCqxOy2kvUA==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@6.3.5:
+    resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.1.4:
+    resolution: {integrity: sha512-Ta56rT7uWxCSJXlBtKgIlApJnT6e6IGmTYxYcmxjJ4ujuZDI59GUQgVDObXXJujOmPDBYXHK1qmaGtneu6TNIQ==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.1.4
+      '@vitest/ui': 3.1.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
@@ -2711,6 +3173,11 @@ packages:
     engines: {node: ^16.13.0 || >=18.0.0}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -2738,10 +3205,6 @@ packages:
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
-  y18n@5.0.8:
-    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
-    engines: {node: '>=10'}
-
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
@@ -2749,21 +3212,9 @@ packages:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
 
-  yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-
   yargs@15.4.1:
     resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
     engines: {node: '>=8'}
-
-  yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
-
-  yocto-queue@0.1.0:
-    resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
-    engines: {node: '>=10'}
 
   zod@3.24.1:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
@@ -2785,6 +3236,11 @@ snapshots:
       undici: 5.28.4
 
   '@actions/io@1.1.3': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -3744,6 +4200,19 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/parser@7.27.2':
+    dependencies:
+      '@babel/types': 7.27.1
+
+  '@babel/types@7.27.1':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
+
   '@bcoe/v8-coverage@1.0.2': {}
 
   '@biomejs/biome@1.9.4':
@@ -3837,6 +4306,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.23.1':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.4':
+    optional: true
+
   '@esbuild/android-arm64@0.18.20':
     optional: true
 
@@ -3844,6 +4316,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.4':
     optional: true
 
   '@esbuild/android-arm@0.18.20':
@@ -3855,6 +4330,9 @@ snapshots:
   '@esbuild/android-arm@0.23.1':
     optional: true
 
+  '@esbuild/android-arm@0.25.4':
+    optional: true
+
   '@esbuild/android-x64@0.18.20':
     optional: true
 
@@ -3862,6 +4340,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.23.1':
+    optional: true
+
+  '@esbuild/android-x64@0.25.4':
     optional: true
 
   '@esbuild/darwin-arm64@0.18.20':
@@ -3873,6 +4354,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.23.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.4':
+    optional: true
+
   '@esbuild/darwin-x64@0.18.20':
     optional: true
 
@@ -3880,6 +4364,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.23.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.4':
     optional: true
 
   '@esbuild/freebsd-arm64@0.18.20':
@@ -3891,6 +4378,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.23.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.4':
+    optional: true
+
   '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
@@ -3898,6 +4388,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.23.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.4':
     optional: true
 
   '@esbuild/linux-arm64@0.18.20':
@@ -3909,6 +4402,9 @@ snapshots:
   '@esbuild/linux-arm64@0.23.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.4':
+    optional: true
+
   '@esbuild/linux-arm@0.18.20':
     optional: true
 
@@ -3916,6 +4412,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.23.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.4':
     optional: true
 
   '@esbuild/linux-ia32@0.18.20':
@@ -3927,6 +4426,9 @@ snapshots:
   '@esbuild/linux-ia32@0.23.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.4':
+    optional: true
+
   '@esbuild/linux-loong64@0.18.20':
     optional: true
 
@@ -3934,6 +4436,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.4':
     optional: true
 
   '@esbuild/linux-mips64el@0.18.20':
@@ -3945,6 +4450,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.23.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.4':
+    optional: true
+
   '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
@@ -3952,6 +4460,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.23.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.4':
     optional: true
 
   '@esbuild/linux-riscv64@0.18.20':
@@ -3963,6 +4474,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.23.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.4':
+    optional: true
+
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
@@ -3970,6 +4484,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.23.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.4':
     optional: true
 
   '@esbuild/linux-x64@0.18.20':
@@ -3981,6 +4498,12 @@ snapshots:
   '@esbuild/linux-x64@0.23.1':
     optional: true
 
+  '@esbuild/linux-x64@0.25.4':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.4':
+    optional: true
+
   '@esbuild/netbsd-x64@0.18.20':
     optional: true
 
@@ -3990,7 +4513,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.23.1':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.4':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.23.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.4':
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
@@ -4002,6 +4531,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.23.1':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.4':
+    optional: true
+
   '@esbuild/sunos-x64@0.18.20':
     optional: true
 
@@ -4009,6 +4541,9 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.23.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.4':
     optional: true
 
   '@esbuild/win32-arm64@0.18.20':
@@ -4020,6 +4555,9 @@ snapshots:
   '@esbuild/win32-arm64@0.23.1':
     optional: true
 
+  '@esbuild/win32-arm64@0.25.4':
+    optional: true
+
   '@esbuild/win32-ia32@0.18.20':
     optional: true
 
@@ -4029,6 +4567,9 @@ snapshots:
   '@esbuild/win32-ia32@0.23.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.4':
+    optional: true
+
   '@esbuild/win32-x64@0.18.20':
     optional: true
 
@@ -4036,6 +4577,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.23.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.4':
     optional: true
 
   '@fastify/busboy@2.1.1': {}
@@ -4207,7 +4751,15 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
+  '@jridgewell/gen-mapping@0.3.8':
+    dependencies:
+      '@jridgewell/set-array': 1.2.1
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/trace-mapping': 0.3.25
+
   '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/set-array@1.2.1': {}
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
@@ -4560,6 +5112,66 @@ snapshots:
     dependencies:
       '@actions/core': 1.11.1
       stack-utils: 2.0.6
+
+  '@rollup/rollup-android-arm-eabi@4.41.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.41.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.41.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.41.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.41.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.41.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.41.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.41.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.41.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.41.1':
+    optional: true
+
+  '@rollup/rollup-linux-loongarch64-gnu@4.41.1':
+    optional: true
+
+  '@rollup/rollup-linux-powerpc64le-gnu@4.41.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.41.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.41.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.41.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.41.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.41.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.41.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.41.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.41.1':
+    optional: true
 
   '@sentry/core@8.47.0': {}
 
@@ -5055,11 +5667,11 @@ snapshots:
     dependencies:
       '@types/node': 22.15.3
 
+  '@types/estree@1.0.7': {}
+
   '@types/fluent-ffmpeg@2.1.27':
     dependencies:
       '@types/node': 22.15.3
-
-  '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/linkify-it@5.0.0': {}
 
@@ -5112,6 +5724,64 @@ snapshots:
       '@types/node': 22.15.3
     optional: true
 
+  '@vitest/coverage-v8@3.1.4(vitest@3.1.4(@types/node@22.15.3)(tsx@4.19.2))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      debug: 4.4.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.1.7
+      magic-string: 0.30.17
+      magicast: 0.3.5
+      std-env: 3.9.0
+      test-exclude: 7.0.1
+      tinyrainbow: 2.0.0
+      vitest: 3.1.4(@types/node@22.15.3)(tsx@4.19.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@3.1.4':
+    dependencies:
+      '@vitest/spy': 3.1.4
+      '@vitest/utils': 3.1.4
+      chai: 5.2.0
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.1.4(vite@6.3.5(@types/node@22.15.3)(tsx@4.19.2))':
+    dependencies:
+      '@vitest/spy': 3.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 6.3.5(@types/node@22.15.3)(tsx@4.19.2)
+
+  '@vitest/pretty-format@3.1.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.1.4':
+    dependencies:
+      '@vitest/utils': 3.1.4
+      pathe: 2.0.3
+
+  '@vitest/snapshot@3.1.4':
+    dependencies:
+      '@vitest/pretty-format': 3.1.4
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/spy@3.1.4':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@3.1.4':
+    dependencies:
+      '@vitest/pretty-format': 3.1.4
+      loupe: 3.1.3
+      tinyrainbow: 2.0.0
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -5146,6 +5816,8 @@ snapshots:
       pvutils: 1.1.3
       tslib: 2.8.1
 
+  assertion-error@2.0.1: {}
+
   async@0.2.10: {}
 
   balanced-match@1.0.2: {}
@@ -5170,19 +5842,7 @@ snapshots:
 
   bytestreamjs@2.0.1: {}
 
-  c8@10.1.3:
-    dependencies:
-      '@bcoe/v8-coverage': 1.0.2
-      '@istanbuljs/schema': 0.1.3
-      find-up: 5.0.0
-      foreground-child: 3.3.1
-      istanbul-lib-coverage: 3.2.2
-      istanbul-lib-report: 3.0.1
-      istanbul-reports: 3.1.7
-      test-exclude: 7.0.1
-      v8-to-istanbul: 9.3.0
-      yargs: 17.7.2
-      yargs-parser: 21.1.1
+  cac@6.7.14: {}
 
   camelcase@5.3.1: {}
 
@@ -5190,7 +5850,17 @@ snapshots:
 
   case-anything@3.1.0: {}
 
+  chai@5.2.0:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.1.3
+      pathval: 2.0.0
+
   chardet@2.0.0: {}
+
+  check-error@2.1.1: {}
 
   cheerio-select@2.1.0:
     dependencies:
@@ -5223,12 +5893,6 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 6.2.0
 
-  cliui@8.0.1:
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -5248,8 +5912,6 @@ snapshots:
   commander@11.1.0: {}
 
   commander@2.20.3: {}
-
-  convert-source-map@2.0.0: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -5280,6 +5942,8 @@ snapshots:
       ms: 2.1.3
 
   decamelize@1.2.0: {}
+
+  deep-eql@5.0.2: {}
 
   detect-libc@2.0.3: {}
 
@@ -5340,6 +6004,8 @@ snapshots:
       whatwg-encoding: 3.1.1
 
   entities@4.5.0: {}
+
+  es-module-lexer@1.7.0: {}
 
   es-toolkit@1.30.1: {}
 
@@ -5428,9 +6094,39 @@ snapshots:
       '@esbuild/win32-ia32': 0.23.1
       '@esbuild/win32-x64': 0.23.1
 
-  escalade@3.2.0: {}
+  esbuild@0.25.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.4
+      '@esbuild/android-arm': 0.25.4
+      '@esbuild/android-arm64': 0.25.4
+      '@esbuild/android-x64': 0.25.4
+      '@esbuild/darwin-arm64': 0.25.4
+      '@esbuild/darwin-x64': 0.25.4
+      '@esbuild/freebsd-arm64': 0.25.4
+      '@esbuild/freebsd-x64': 0.25.4
+      '@esbuild/linux-arm': 0.25.4
+      '@esbuild/linux-arm64': 0.25.4
+      '@esbuild/linux-ia32': 0.25.4
+      '@esbuild/linux-loong64': 0.25.4
+      '@esbuild/linux-mips64el': 0.25.4
+      '@esbuild/linux-ppc64': 0.25.4
+      '@esbuild/linux-riscv64': 0.25.4
+      '@esbuild/linux-s390x': 0.25.4
+      '@esbuild/linux-x64': 0.25.4
+      '@esbuild/netbsd-arm64': 0.25.4
+      '@esbuild/netbsd-x64': 0.25.4
+      '@esbuild/openbsd-arm64': 0.25.4
+      '@esbuild/openbsd-x64': 0.25.4
+      '@esbuild/sunos-x64': 0.25.4
+      '@esbuild/win32-arm64': 0.25.4
+      '@esbuild/win32-ia32': 0.25.4
+      '@esbuild/win32-x64': 0.25.4
 
   escape-string-regexp@2.0.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.7
 
   etag@1.8.1: {}
 
@@ -5448,6 +6144,8 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  expect-type@1.2.1: {}
+
   fast-xml-parser@4.4.1:
     dependencies:
       strnum: 1.0.5
@@ -5464,11 +6162,6 @@ snapshots:
   find-up@4.1.0:
     dependencies:
       locate-path: 5.0.0
-      path-exists: 4.0.0
-
-  find-up@5.0.0:
-    dependencies:
-      locate-path: 6.0.0
       path-exists: 4.0.0
 
   flattie@1.1.1: {}
@@ -5585,6 +6278,14 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      debug: 4.4.0
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
   istanbul-reports@3.1.7:
     dependencies:
       html-escaper: 2.0.2
@@ -5627,15 +6328,23 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
-  locate-path@6.0.0:
-    dependencies:
-      p-locate: 5.0.0
+  loupe@3.1.3: {}
 
   lru-cache@10.4.3: {}
 
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
+
+  magic-string@0.30.17:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.27.2
+      '@babel/types': 7.27.1
+      source-map-js: 1.2.1
 
   make-dir@4.0.0:
     dependencies:
@@ -5689,6 +6398,8 @@ snapshots:
 
   multiformats@9.9.0: {}
 
+  nanoid@3.3.11: {}
+
   neat-csv@7.0.0:
     dependencies:
       csv-parser: 3.1.0
@@ -5735,17 +6446,9 @@ snapshots:
     dependencies:
       p-try: 2.2.0
 
-  p-limit@3.1.0:
-    dependencies:
-      yocto-queue: 0.1.0
-
   p-locate@4.1.0:
     dependencies:
       p-limit: 2.3.0
-
-  p-locate@5.0.0:
-    dependencies:
-      p-limit: 3.1.0
 
   p-try@2.2.0: {}
 
@@ -5775,6 +6478,10 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  pathe@2.0.3: {}
+
+  pathval@2.0.0: {}
+
   pg-int8@1.0.1: {}
 
   pg-protocol@1.7.0: {}
@@ -5786,6 +6493,8 @@ snapshots:
       postgres-bytea: 1.0.0
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
+
+  picocolors@1.1.1: {}
 
   picomatch@4.0.2: {}
 
@@ -5801,6 +6510,12 @@ snapshots:
   pluralize@8.0.0: {}
 
   pngjs@5.0.0: {}
+
+  postcss@8.5.3:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postgres-array@2.0.0: {}
 
@@ -5852,6 +6567,32 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  rollup@4.41.1:
+    dependencies:
+      '@types/estree': 1.0.7
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.41.1
+      '@rollup/rollup-android-arm64': 4.41.1
+      '@rollup/rollup-darwin-arm64': 4.41.1
+      '@rollup/rollup-darwin-x64': 4.41.1
+      '@rollup/rollup-freebsd-arm64': 4.41.1
+      '@rollup/rollup-freebsd-x64': 4.41.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.41.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.41.1
+      '@rollup/rollup-linux-arm64-gnu': 4.41.1
+      '@rollup/rollup-linux-arm64-musl': 4.41.1
+      '@rollup/rollup-linux-loongarch64-gnu': 4.41.1
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.41.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.41.1
+      '@rollup/rollup-linux-riscv64-musl': 4.41.1
+      '@rollup/rollup-linux-s390x-gnu': 4.41.1
+      '@rollup/rollup-linux-x64-gnu': 4.41.1
+      '@rollup/rollup-linux-x64-musl': 4.41.1
+      '@rollup/rollup-win32-arm64-msvc': 4.41.1
+      '@rollup/rollup-win32-ia32-msvc': 4.41.1
+      '@rollup/rollup-win32-x64-msvc': 4.41.1
+      fsevents: 2.3.3
+
   safe-stable-stringify@2.5.0: {}
 
   safer-buffer@2.1.2: {}
@@ -5898,6 +6639,8 @@ snapshots:
 
   shimmer@1.2.1: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -5909,6 +6652,8 @@ snapshots:
   slash@5.1.0: {}
 
   slugify@1.6.6: {}
+
+  source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
     dependencies:
@@ -5922,6 +6667,10 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  stackback@0.0.2: {}
+
+  std-env@3.9.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -5958,6 +6707,21 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 10.4.5
       minimatch: 9.0.5
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.14:
+    dependencies:
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
+
+  tinypool@1.0.2: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@3.0.2: {}
 
   truncatise@0.0.8: {}
 
@@ -6001,13 +6765,80 @@ snapshots:
 
   uuidv7-js@1.1.4: {}
 
-  v8-to-istanbul@9.3.0:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      '@types/istanbul-lib-coverage': 2.0.6
-      convert-source-map: 2.0.0
-
   varint@6.0.0: {}
+
+  vite-node@3.1.4(@types/node@22.15.3)(tsx@4.19.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.0
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 6.3.5(@types/node@22.15.3)(tsx@4.19.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@6.3.5(@types/node@22.15.3)(tsx@4.19.2):
+    dependencies:
+      esbuild: 0.25.4
+      fdir: 6.4.4(picomatch@4.0.2)
+      picomatch: 4.0.2
+      postcss: 8.5.3
+      rollup: 4.41.1
+      tinyglobby: 0.2.14
+    optionalDependencies:
+      '@types/node': 22.15.3
+      fsevents: 2.3.3
+      tsx: 4.19.2
+
+  vitest@3.1.4(@types/node@22.15.3)(tsx@4.19.2):
+    dependencies:
+      '@vitest/expect': 3.1.4
+      '@vitest/mocker': 3.1.4(vite@6.3.5(@types/node@22.15.3)(tsx@4.19.2))
+      '@vitest/pretty-format': 3.1.4
+      '@vitest/runner': 3.1.4
+      '@vitest/snapshot': 3.1.4
+      '@vitest/spy': 3.1.4
+      '@vitest/utils': 3.1.4
+      chai: 5.2.0
+      debug: 4.4.0
+      expect-type: 1.2.1
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.0.2
+      tinyrainbow: 2.0.0
+      vite: 6.3.5(@types/node@22.15.3)(tsx@4.19.2)
+      vite-node: 3.1.4(@types/node@22.15.3)(tsx@4.19.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.15.3
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   web-streams-polyfill@3.3.3: {}
 
@@ -6030,6 +6861,11 @@ snapshots:
   which@4.0.0:
     dependencies:
       isexe: 3.1.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrap-ansi@6.2.0:
     dependencies:
@@ -6060,16 +6896,12 @@ snapshots:
 
   y18n@4.0.3: {}
 
-  y18n@5.0.8: {}
-
   yallist@4.0.0: {}
 
   yargs-parser@18.1.3:
     dependencies:
       camelcase: 5.3.1
       decamelize: 1.2.0
-
-  yargs-parser@21.1.1: {}
 
   yargs@15.4.1:
     dependencies:
@@ -6084,17 +6916,5 @@ snapshots:
       which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
-
-  yargs@17.7.2:
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.2.0
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
-
-  yocto-queue@0.1.0: {}
 
   zod@3.24.1: {}

--- a/src/api/v1/accounts.test.ts
+++ b/src/api/v1/accounts.test.ts
@@ -1,5 +1,4 @@
-import { afterEach, beforeEach, describe, it } from "node:test";
-import type { TestContext } from "node:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { cleanDatabase } from "../../../tests/helpers";
 import {
@@ -11,7 +10,7 @@ import {
 
 import app from "../../index";
 
-describe("/api/v1/accounts/", () => {
+describe.sequential("/api/v1/accounts/verify_credentials", () => {
   let client: Awaited<ReturnType<typeof createOAuthApplication>>;
   let account: Awaited<ReturnType<typeof createAccount>>;
 
@@ -26,81 +25,70 @@ describe("/api/v1/accounts/", () => {
     await cleanDatabase();
   });
 
-  describe("verify_credentials", () => {
-    it("Successfully returns the current accounts profile with a valid access token", async (t: TestContext) => {
-      t.plan(7);
+  it("Successfully returns the current accounts profile with a valid access token", async () => {
+    expect.assertions(7);
 
-      const accessToken = await getAccessToken(client, account, [
-        "read:accounts",
-      ]);
+    const accessToken = await getAccessToken(client, account, [
+      "read:accounts",
+    ]);
 
-      const response = await app.request(
-        "/api/v1/accounts/verify_credentials",
-        {
-          method: "GET",
-          headers: {
-            authorization: bearerAuthorization(accessToken),
-          },
-        },
-      );
-
-      t.assert.equal(response.status, 200);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
-      t.assert.equal(response.headers.get("access-control-allow-origin"), "*");
-
-      const credentialAccount = await response.json();
-
-      t.assert.equal(typeof credentialAccount, "object");
-      t.assert.equal(credentialAccount.id, account.id);
-      t.assert.equal(credentialAccount.username, "hollo");
-      t.assert.equal(credentialAccount.acct, "hollo@hollo.test");
+    const response = await app.request("/api/v1/accounts/verify_credentials", {
+      method: "GET",
+      headers: {
+        authorization: bearerAuthorization(accessToken),
+      },
     });
 
-    it("does not return the account when an invalid scope is used", async (t: TestContext) => {
-      t.plan(4);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
 
-      const accessToken = await getAccessToken(client, account, ["write"]);
+    const credentialAccount = await response.json();
 
-      const response = await app.request(
-        "/api/v1/accounts/verify_credentials",
-        {
-          method: "GET",
-          headers: {
-            authorization: bearerAuthorization(accessToken),
-          },
-        },
-      );
+    expect(typeof credentialAccount).toBe("object");
+    expect(credentialAccount.id).toBe(account.id);
+    expect(credentialAccount.username).toBe("hollo");
+    expect(credentialAccount.acct).toBe("hollo@hollo.test");
+  });
 
-      t.assert.equal(response.status, 403);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
-      t.assert.equal(response.headers.get("access-control-allow-origin"), "*");
+  it("does not return the account when an invalid scope is used", async () => {
+    expect.assertions(4);
 
-      const error = await response.json();
+    const accessToken = await getAccessToken(client, account, ["write"]);
 
-      t.assert.deepStrictEqual(error, {
-        error: "insufficient_scope",
-      });
+    const response = await app.request("/api/v1/accounts/verify_credentials", {
+      method: "GET",
+      headers: {
+        authorization: bearerAuthorization(accessToken),
+      },
     });
 
-    it("does not return the account when no access token is used", async (t: TestContext) => {
-      t.plan(4);
+    expect(response.status).toBe(403);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
 
-      const response = await app.request(
-        "/api/v1/accounts/verify_credentials",
-        {
-          method: "GET",
-        },
-      );
+    const error = await response.json();
 
-      t.assert.equal(response.status, 401);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
-      t.assert.equal(response.headers.get("access-control-allow-origin"), "*");
+    expect(error).toMatchObject({
+      error: "insufficient_scope",
+    });
+  });
 
-      const error = await response.json();
+  it("does not return the account when no access token is used", async () => {
+    expect.assertions(4);
 
-      t.assert.deepStrictEqual(error, {
-        error: "unauthorized",
-      });
+    const response = await app.request("/api/v1/accounts/verify_credentials", {
+      method: "GET",
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toBe("application/json");
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+
+    const error = await response.json();
+
+    expect(error).toMatchObject({
+      error: "unauthorized",
     });
   });
 });

--- a/src/api/v1/apps.ts
+++ b/src/api/v1/apps.ts
@@ -60,7 +60,7 @@ app.post("/", async (c) => {
   const result = await requestBody(c.req, applicationSchema);
 
   if (!result.success) {
-    logger.debug("Invalid request: {error}", { error: result.error });
+    logger.debug("Invalid request: {error}", { error: result.error.errors });
     return c.json({ error: "invalid_request", zod_error: result.error }, 422);
   }
 

--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -1,5 +1,4 @@
-import { afterEach, beforeEach, describe, it } from "node:test";
-import type { TestContext } from "node:test";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import app from "./index";
 import type * as Schema from "./schema";
@@ -21,86 +20,74 @@ import { getLoginCookie } from "../tests/helpers/web";
 import { OOB_REDIRECT_URI } from "./oauth/constants";
 import { createAccessGrant } from "./oauth/helpers";
 
-describe("OAuth", () => {
-  it(
-    "Can GET /.well-known/oauth-authorization-server",
-    { plan: 11 },
-    async (t: TestContext) => {
-      // We use the full URL in this test as the route calculates values based
-      // on the Host header
-      const response = await app.request(
-        "http://localhost:3000/.well-known/oauth-authorization-server",
-        {
-          method: "GET",
-        },
-      );
-
-      t.assert.equal(response.status, 200, "Should return 200-ok");
-
-      const metadata = await response.json();
-
-      t.assert.equal(metadata.issuer, "http://localhost:3000/");
-      t.assert.equal(
-        metadata.authorization_endpoint,
-        "http://localhost:3000/oauth/authorize",
-      );
-      t.assert.equal(
-        metadata.token_endpoint,
-        "http://localhost:3000/oauth/token",
-      );
-      t.assert.equal(
-        metadata.revocation_endpoint,
-        "http://localhost:3000/oauth/revoke",
-      );
-      // Non-standard, mastodon extension:
-      t.assert.equal(
-        metadata.app_registration_endpoint,
-        "http://localhost:3000/api/v1/apps",
-      );
-
-      t.assert.deepStrictEqual(metadata.response_types_supported, ["code"]);
-      t.assert.deepStrictEqual(metadata.response_modes_supported, ["query"]);
-      t.assert.deepStrictEqual(metadata.grant_types_supported, [
-        "authorization_code",
-        "client_credentials",
-      ]);
-      t.assert.deepStrictEqual(metadata.token_endpoint_auth_methods_supported, [
-        "client_secret_post",
-        "client_secret_basic",
-      ]);
-
-      t.assert.ok(
-        Array.isArray(metadata.scopes_supported),
-        "Should return an array of scopes supported",
-      );
-    },
-  );
-});
-
-describe("OAuth / POST /oauth/authorize", () => {
-  let application: Schema.Application;
-  let client: Awaited<ReturnType<typeof createOAuthApplication>>;
-  let account: Awaited<ReturnType<typeof createAccount>>;
-  const APP_REDIRECT_URI = "custom://oauth_callback";
-
-  beforeEach(async () => {
-    account = await createAccount();
-    client = await createOAuthApplication({
-      scopes: ["read:accounts"],
-      redirectUris: [OOB_REDIRECT_URI, APP_REDIRECT_URI],
-      confidential: true,
-    });
-    application = await getApplication(client);
-  });
-
+describe.sequential("OAuth", () => {
   afterEach(async () => {
     await cleanDatabase();
   });
 
-  it(
-    "Does not create an access grant if denied",
-    { plan: 2 },
-    async (t: TestContext) => {
+  it("Can GET /.well-known/oauth-authorization-server", async () => {
+    expect.assertions(12);
+    // We use the full URL in this test as the route calculates values based
+    // on the Host header
+    const response = await app.request(
+      "http://localhost:3000/.well-known/oauth-authorization-server",
+      {
+        method: "GET",
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const metadata = await response.json();
+
+    expect(metadata.issuer).toBe("http://localhost:3000/");
+    expect(metadata.authorization_endpoint).toBe(
+      "http://localhost:3000/oauth/authorize",
+    );
+    expect(metadata.token_endpoint).toBe("http://localhost:3000/oauth/token");
+    expect(metadata.revocation_endpoint).toBe(
+      "http://localhost:3000/oauth/revoke",
+    );
+    // Non-standard, mastodon extension:
+    expect(metadata.app_registration_endpoint).toBe(
+      "http://localhost:3000/api/v1/apps",
+    );
+
+    expect(metadata.response_types_supported).toEqual(["code"]);
+    expect(metadata.response_modes_supported).toEqual(["query"]);
+    expect(metadata.grant_types_supported).toEqual([
+      "authorization_code",
+      "client_credentials",
+    ]);
+    expect(metadata.token_endpoint_auth_methods_supported).toEqual([
+      "client_secret_post",
+      "client_secret_basic",
+    ]);
+
+    expect(metadata.scopes_supported).to;
+
+    expect(Array.isArray(metadata.scopes_supported)).toBeTruthy();
+  });
+
+  describe.sequential("POST /oauth/authorize", () => {
+    let application: Schema.Application;
+    let client: Awaited<ReturnType<typeof createOAuthApplication>>;
+    let account: Awaited<ReturnType<typeof createAccount>>;
+    const APP_REDIRECT_URI = "custom://oauth_callback";
+
+    beforeEach(async () => {
+      account = await createAccount();
+      client = await createOAuthApplication({
+        scopes: ["read:accounts"],
+        redirectUris: [OOB_REDIRECT_URI, APP_REDIRECT_URI],
+        confidential: true,
+      });
+      application = await getApplication(client);
+    });
+
+    it("Does not create an access grant if denied", async () => {
+      expect.assertions(2);
+
       const cookie = await getLoginCookie();
       const formData = new FormData();
 
@@ -118,18 +105,15 @@ describe("OAuth / POST /oauth/authorize", () => {
         },
       });
 
-      t.assert.equal(response.status, 302);
-      t.assert.equal(
-        response.headers.get("Location"),
+      expect(response.status).toBe(302);
+      expect(response.headers.get("Location")).toBe(
         "custom://oauth_callback?error=access_denied&error_description=The+resource+owner+or+authorization+server+denied+the+request.",
       );
-    },
-  );
+    });
 
-  it(
-    "Can return authorization code out-of-bounds",
-    { plan: 8 },
-    async (t: TestContext) => {
+    it("Can return authorization code out-of-bounds", async () => {
+      expect.assertions(8);
+
       const cookie = await getLoginCookie();
       const formData = new FormData();
 
@@ -147,30 +131,23 @@ describe("OAuth / POST /oauth/authorize", () => {
         },
       });
 
-      t.assert.equal(response.status, 200);
-      t.assert.match(response.headers.get("content-type") ?? "", /text\/html/);
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type") ?? "").toMatch(/text\/html/);
 
       const responseBody = await response.text();
       const lastAccessGrant = await getLastAccessGrant();
 
-      t.assert.equal(lastAccessGrant.applicationId, application.id);
-      t.assert.equal(lastAccessGrant.resourceOwnerId, account.id);
-      t.assert.equal(lastAccessGrant.redirectUri, OOB_REDIRECT_URI);
-      t.assert.deepStrictEqual(lastAccessGrant.scopes, ["read:accounts"]);
-      t.assert.strictEqual(lastAccessGrant.revoked, null);
+      expect(lastAccessGrant.applicationId).toBe(application.id);
+      expect(lastAccessGrant.resourceOwnerId).toBe(account.id);
+      expect(lastAccessGrant.redirectUri).toBe(OOB_REDIRECT_URI);
+      expect(lastAccessGrant.scopes).toEqual(["read:accounts"]);
+      expect(lastAccessGrant.revoked).toBeNull();
 
-      t.assert.match(
-        responseBody,
-        new RegExp(`${lastAccessGrant.code}`),
-        "Response should contain the access grant code",
-      );
-    },
-  );
+      expect(responseBody).toMatch(new RegExp(`${lastAccessGrant.code}`));
+    });
 
-  it(
-    "Can return authorization code via redirect",
-    { plan: 7 },
-    async (t: TestContext) => {
+    it("Can return authorization code via redirect", async () => {
+      expect.assertions(7);
       const cookie = await getLoginCookie();
       const formData = new FormData();
 
@@ -189,55 +166,156 @@ describe("OAuth / POST /oauth/authorize", () => {
         },
       });
 
-      t.assert.equal(response.status, 302);
+      expect(response.status).toBe(302);
 
       const lastAccessGrant = await getLastAccessGrant();
-      t.assert.equal(lastAccessGrant.applicationId, application.id);
-      t.assert.equal(lastAccessGrant.resourceOwnerId, account.id);
-      t.assert.equal(lastAccessGrant.redirectUri, APP_REDIRECT_URI);
-      t.assert.deepStrictEqual(lastAccessGrant.scopes, ["read:accounts"]);
-      t.assert.strictEqual(lastAccessGrant.revoked, null);
+      expect(lastAccessGrant.applicationId).toBe(application.id);
+      expect(lastAccessGrant.resourceOwnerId).toBe(account.id);
+      expect(lastAccessGrant.redirectUri).toBe(APP_REDIRECT_URI);
+      expect(lastAccessGrant.scopes).toEqual(["read:accounts"]);
+      expect(lastAccessGrant.revoked).toBeNull();
 
-      t.assert.equal(
-        response.headers.get("Location"),
+      expect(response.headers.get("Location")).toBe(
         `${APP_REDIRECT_URI}?code=${lastAccessGrant.code}&state=test_state_value`,
       );
-    },
-  );
-});
-
-describe("OAuth / POST /oauth/token (Confidential Client)", () => {
-  let account: Awaited<ReturnType<typeof createAccount>>;
-  let application: Schema.Application;
-  let client: Awaited<ReturnType<typeof createOAuthApplication>>;
-  let wrongApplication: Schema.Application;
-  let wrongClient: Awaited<ReturnType<typeof createOAuthApplication>>;
-
-  beforeEach(async () => {
-    account = await createAccount();
-    client = await createOAuthApplication({
-      scopes: ["read:accounts"],
-      redirectUris: [OOB_REDIRECT_URI],
-      confidential: true,
     });
-    application = await getApplication(client);
 
-    wrongClient = await createOAuthApplication({
-      scopes: ["write:accounts"],
-      redirectUris: [OOB_REDIRECT_URI],
-      confidential: true,
+    it("returns an error if the application does not exist", async () => {
+      expect.assertions(1);
+
+      const cookie = await getLoginCookie();
+      const formData = new FormData();
+
+      formData.set("account_id", account.id);
+      formData.set("application_id", "403dafb4-9c37-4dfc-bfb4-02fb0cf681fb");
+      formData.set("redirect_uri", OOB_REDIRECT_URI);
+      // write:accounts is not a registered scope for the application:
+      formData.set("scopes", "write:accounts");
+      formData.set("decision", "allow");
+
+      const response = await app.request("/oauth/authorize", {
+        method: "POST",
+        body: formData,
+        headers: {
+          Cookie: cookie,
+        },
+      });
+
+      expect(response.status).toBe(404);
     });
-    wrongApplication = await getApplication(wrongClient);
+
+    it("returns an error if the account does not exist", async () => {
+      expect.assertions(1);
+
+      const cookie = await getLoginCookie();
+      const formData = new FormData();
+
+      formData.set("account_id", "403dafb4-9c37-4dfc-bfb4-02fb0cf681fb");
+      formData.set("application_id", application.id);
+      formData.set("redirect_uri", OOB_REDIRECT_URI);
+      // write:accounts is not a registered scope for the application:
+      formData.set("scopes", "write:accounts");
+      formData.set("decision", "allow");
+
+      const response = await app.request("/oauth/authorize", {
+        method: "POST",
+        body: formData,
+        headers: {
+          Cookie: cookie,
+        },
+      });
+
+      expect(response.status).toBe(404);
+    });
+
+    it("returns an error if the scopes does not match the application scopes", async () => {
+      expect.assertions(2);
+
+      const cookie = await getLoginCookie();
+      const formData = new FormData();
+
+      formData.set("account_id", account.id);
+      formData.set("application_id", application.id);
+      formData.set("redirect_uri", OOB_REDIRECT_URI);
+      // write:accounts is not a registered scope for the application:
+      formData.set("scopes", "write:accounts");
+      formData.set("decision", "allow");
+
+      const response = await app.request("/oauth/authorize", {
+        method: "POST",
+        body: formData,
+        headers: {
+          Cookie: cookie,
+        },
+      });
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+
+      expect(body).toMatchObject({
+        error: "invalid_scope",
+      });
+    });
+
+    it("returns an error if the redirect_uri does not match the application redirect URIs", async () => {
+      expect.assertions(2);
+
+      const cookie = await getLoginCookie();
+      const formData = new FormData();
+
+      formData.set("account_id", account.id);
+      formData.set("application_id", application.id);
+      formData.set("redirect_uri", "https://invalid.example/");
+      formData.set("scopes", "read:accounts");
+      formData.set("decision", "allow");
+
+      const response = await app.request("/oauth/authorize", {
+        method: "POST",
+        body: formData,
+        headers: {
+          Cookie: cookie,
+        },
+      });
+
+      expect(response.status).toBe(400);
+      const body = await response.json();
+
+      expect(body).toMatchObject({
+        error: "invalid_redirect_uri",
+      });
+    });
   });
 
-  afterEach(async () => {
-    await cleanDatabase();
-  });
+  describe.sequential("OAuth / POST /oauth/token (Confidential Client)", () => {
+    let account: Awaited<ReturnType<typeof createAccount>>;
+    let application: Schema.Application;
+    let client: Awaited<ReturnType<typeof createOAuthApplication>>;
+    let wrongApplication: Schema.Application;
+    let wrongClient: Awaited<ReturnType<typeof createOAuthApplication>>;
 
-  it(
-    "cannot request an access token without using a client authentication method",
-    { plan: 3 },
-    async (t: TestContext) => {
+    beforeEach(async () => {
+      account = await createAccount();
+      client = await createOAuthApplication({
+        scopes: ["read:accounts"],
+        redirectUris: [OOB_REDIRECT_URI],
+        confidential: true,
+      });
+      application = await getApplication(client);
+
+      wrongClient = await createOAuthApplication({
+        scopes: ["write:accounts"],
+        redirectUris: [OOB_REDIRECT_URI],
+        confidential: true,
+      });
+      wrongApplication = await getApplication(wrongClient);
+    });
+
+    afterEach(async () => {
+      await cleanDatabase();
+    });
+
+    it("cannot request an access token without using a client authentication method", async () => {
+      expect.assertions(3);
       // Here we are deliberately not using any client authentication method,
       // which is not acceptable
 
@@ -250,18 +328,15 @@ describe("OAuth / POST /oauth/token (Confidential Client)", () => {
         body,
       });
 
-      t.assert.equal(response.status, 401);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(401);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const responseBody = await response.json();
-      t.assert.equal(responseBody.error, "invalid_client");
-    },
-  );
+      expect(responseBody.error).toBe("invalid_client");
+    });
 
-  it(
-    "cannot request an access token using multiple client authentication methods",
-    { plan: 3 },
-    async (t: TestContext) => {
+    it("cannot request an access token using multiple client authentication methods", async () => {
+      expect.assertions(3);
       // Here we are using both client_secret_post and client_secret_basic
       // together, which is not acceptable
 
@@ -279,18 +354,15 @@ describe("OAuth / POST /oauth/token (Confidential Client)", () => {
         body,
       });
 
-      t.assert.equal(response.status, 400);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(400);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const responseBody = await response.json();
-      t.assert.equal(responseBody.error, "invalid_request");
-    },
-  );
+      expect(responseBody.error).toBe("invalid_request");
+    });
 
-  it(
-    "cannot request an access token using invalid client authentication",
-    { plan: 3 },
-    async (t: TestContext) => {
+    it("cannot request an access token using invalid client authentication", async () => {
+      expect.assertions(3);
       const body = new FormData();
       body.set("grant_type", "client_credentials");
       body.set("client_id", application.clientId);
@@ -302,19 +374,16 @@ describe("OAuth / POST /oauth/token (Confidential Client)", () => {
         body,
       });
 
-      t.assert.equal(response.status, 401);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(401);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const responseBody = await response.json();
-      t.assert.equal(responseBody.error, "invalid_client");
-    },
-  );
+      expect(responseBody.error).toBe("invalid_client");
+    });
 
-  // Client Credentials Grant Flow
-  it(
-    "can request an access token using the client credentials grant flow with client_secret_basic",
-    { plan: 7 },
-    async (t: TestContext) => {
+    // Client Credentials Grant Flow
+    it("can request an access token using the client credentials grant flow with client_secret_basic", async () => {
+      expect.assertions(7);
       const body = new FormData();
       body.set("grant_type", "client_credentials");
       body.set("scope", "read:accounts");
@@ -327,28 +396,21 @@ describe("OAuth / POST /oauth/token (Confidential Client)", () => {
         body,
       });
 
-      t.assert.equal(response.status, 200);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const responseBody = await response.json();
       const lastAccessToken = await getLastAccessToken();
 
-      t.assert.equal(lastAccessToken.grant_type, "client_credentials");
-      t.assert.deepStrictEqual(lastAccessToken.scopes, ["read:accounts"]);
-      t.assert.equal(
-        responseBody.access_token,
-        lastAccessToken.code,
-        "Generates an Access Token",
-      );
-      t.assert.equal(responseBody.token_type, "Bearer");
-      t.assert.equal(responseBody.scope, lastAccessToken.scopes.join(" "));
-    },
-  );
+      expect(lastAccessToken.grant_type).toBe("client_credentials");
+      expect(lastAccessToken.scopes).toEqual(["read:accounts"]);
+      expect(responseBody.access_token).toBe(lastAccessToken.code);
+      expect(responseBody.token_type).toBe("Bearer");
+      expect(responseBody.scope).toBe(lastAccessToken.scopes.join(" "));
+    });
 
-  it(
-    "can request an access token using the client credentials grant flow with client_secret_post",
-    { plan: 7 },
-    async (t: TestContext) => {
+    it("can request an access token using the client credentials grant flow with client_secret_post", async () => {
+      expect.assertions(7);
       const body = new FormData();
       body.set("grant_type", "client_credentials");
       body.set("client_id", application.clientId);
@@ -360,28 +422,21 @@ describe("OAuth / POST /oauth/token (Confidential Client)", () => {
         body,
       });
 
-      t.assert.equal(response.status, 200);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const responseBody = await response.json();
       const lastAccessToken = await getLastAccessToken();
 
-      t.assert.equal(lastAccessToken.grant_type, "client_credentials");
-      t.assert.deepStrictEqual(lastAccessToken.scopes, ["read:accounts"]);
-      t.assert.equal(
-        responseBody.access_token,
-        lastAccessToken.code,
-        "Generates an Access Token",
-      );
-      t.assert.equal(responseBody.token_type, "Bearer");
-      t.assert.equal(responseBody.scope, lastAccessToken.scopes.join(" "));
-    },
-  );
+      expect(lastAccessToken.grant_type).toBe("client_credentials");
+      expect(lastAccessToken.scopes).toEqual(["read:accounts"]);
+      expect(responseBody.access_token).toBe(lastAccessToken.code);
+      expect(responseBody.token_type).toBe("Bearer");
+      expect(responseBody.scope).toBe(lastAccessToken.scopes.join(" "));
+    });
 
-  it(
-    "can request an access token using the client credentials grant flow using JSON body",
-    { plan: 7 },
-    async (t: TestContext) => {
+    it("can request an access token using the client credentials grant flow using JSON body", async () => {
+      expect.assertions(7);
       const body = JSON.stringify({
         grant_type: "client_credentials",
         client_id: application.clientId,
@@ -397,28 +452,21 @@ describe("OAuth / POST /oauth/token (Confidential Client)", () => {
         body,
       });
 
-      t.assert.equal(response.status, 200);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const lastAccessToken = await getLastAccessToken();
       const responseBody = await response.json();
 
-      t.assert.equal(lastAccessToken.grant_type, "client_credentials");
-      t.assert.deepStrictEqual(lastAccessToken.scopes, ["read:accounts"]);
-      t.assert.equal(
-        responseBody.access_token,
-        lastAccessToken.code,
-        "Generates an Access Token",
-      );
-      t.assert.equal(responseBody.token_type, "Bearer");
-      t.assert.equal(responseBody.scope, lastAccessToken.scopes.join(" "));
-    },
-  );
+      expect(lastAccessToken.grant_type).toBe("client_credentials");
+      expect(lastAccessToken.scopes).toEqual(["read:accounts"]);
+      expect(responseBody.access_token).toBe(lastAccessToken.code);
+      expect(responseBody.token_type).toBe("Bearer");
+      expect(responseBody.scope).toBe(lastAccessToken.scopes.join(" "));
+    });
 
-  it(
-    "cannot request client credentials grant flow with scope not registered to the application",
-    { plan: 4 },
-    async (t: TestContext) => {
+    it("cannot request client credentials grant flow with scope not registered to the application", async () => {
+      expect.assertions(4);
       const body = new FormData();
       body.set("grant_type", "client_credentials");
       body.set("scope", "write:accounts");
@@ -431,20 +479,17 @@ describe("OAuth / POST /oauth/token (Confidential Client)", () => {
         body,
       });
 
-      t.assert.equal(response.status, 400);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
-      t.assert.equal(response.headers.get("access-control-allow-origin"), "*");
+      expect(response.status).toBe(400);
+      expect(response.headers.get("content-type")).toBe("application/json");
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
 
       const responseBody = await response.json();
-      t.assert.equal(responseBody.error, "invalid_scope");
-    },
-  );
+      expect(responseBody.error).toBe("invalid_scope");
+    });
 
-  // OAuth Authorization Code Grant Flow
-  it(
-    "can exchange an access grant for an access token",
-    { plan: 8 },
-    async (t: TestContext) => {
+    // OAuth Authorization Code Grant Flow
+    it("can exchange an access grant for an access token", async () => {
+      expect.assertions(8);
       const accessGrant = await createAccessGrant(
         application.id,
         account.id,
@@ -465,44 +510,30 @@ describe("OAuth / POST /oauth/token (Confidential Client)", () => {
         body,
       });
 
-      t.assert.equal(response.status, 200);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const responseBody = await response.json();
 
       const lastAccessToken = await getLastAccessToken();
       const changedAccessGrant = await findAccessGrant(accessGrant.code);
 
-      t.assert.notEqual(
-        changedAccessGrant.revoked,
-        null,
-        "Successfully revokes the access grant",
-      );
-      t.assert.equal(lastAccessToken.grant_type, "authorization_code");
-      t.assert.deepStrictEqual(
-        lastAccessToken.scopes,
-        changedAccessGrant.scopes,
-      );
+      expect(changedAccessGrant.revoked).not.toBeNull();
+      expect(lastAccessToken.grant_type).toBe("authorization_code");
+      expect(lastAccessToken.scopes).toEqual(changedAccessGrant.scopes);
 
-      t.assert.equal(
-        responseBody.access_token,
-        lastAccessToken.code,
-        "Generates an Access Token",
-      );
-      t.assert.equal(responseBody.token_type, "Bearer");
-      t.assert.equal(responseBody.scope, lastAccessToken.scopes.join(" "));
-    },
-  );
+      expect(responseBody.access_token).toBe(lastAccessToken.code);
+      expect(responseBody.token_type).toBe("Bearer");
+      expect(responseBody.scope).toBe(lastAccessToken.scopes.join(" "));
+    });
 
-  // This test case needs time travel, lines 332-339
-  it.skip(
-    "cannot exchange an access grant for an access token when the access grant has expired",
-  );
+    // This test case needs time travel, lines 332-339
+    it.skip(
+      "cannot exchange an access grant for an access token when the access grant has expired",
+    );
 
-  it(
-    "cannot exchange an access grant for an access token when the redirect URI does not match",
-    { plan: 3 },
-    async (t: TestContext) => {
+    it("cannot exchange an access grant for an access token when the redirect URI does not match", async () => {
+      expect.assertions(3);
       const accessGrant = await createAccessGrant(
         application.id,
         account.id,
@@ -523,19 +554,16 @@ describe("OAuth / POST /oauth/token (Confidential Client)", () => {
         body,
       });
 
-      t.assert.equal(response.status, 400);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(400);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const responseBody = await response.json();
 
-      t.assert.equal(responseBody.error, "invalid_grant");
-    },
-  );
+      expect(responseBody.error).toBe("invalid_grant");
+    });
 
-  it(
-    "cannot exchange an access grant for an access token when the client does not match",
-    { plan: 3 },
-    async (t: TestContext) => {
+    it("cannot exchange an access grant for an access token when the client does not match", async () => {
+      expect.assertions(3);
       const accessGrant = await createAccessGrant(
         application.id,
         account.id,
@@ -556,19 +584,16 @@ describe("OAuth / POST /oauth/token (Confidential Client)", () => {
         body,
       });
 
-      t.assert.equal(response.status, 400);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(400);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const responseBody = await response.json();
 
-      t.assert.equal(responseBody.error, "invalid_grant");
-    },
-  );
+      expect(responseBody.error).toBe("invalid_grant");
+    });
 
-  it(
-    "cannot exchange an access grant for an access token when the access grant is revoked",
-    { plan: 3 },
-    async (t: TestContext) => {
+    it("cannot exchange an access grant for an access token when the access grant is revoked", async () => {
+      expect.assertions(3);
       const accessGrant = await createAccessGrant(
         application.id,
         account.id,
@@ -591,20 +616,17 @@ describe("OAuth / POST /oauth/token (Confidential Client)", () => {
         body,
       });
 
-      t.assert.equal(response.status, 400);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(400);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const responseBody = await response.json();
 
-      t.assert.equal(responseBody.error, "invalid_grant");
-    },
-  );
+      expect(responseBody.error).toBe("invalid_grant");
+    });
 
-  // Unsupported authorization grant flow:
-  it(
-    "cannot use an unsupported grant_type",
-    { plan: 4 },
-    async (t: TestContext) => {
+    // Unsupported authorization grant flow:
+    it("cannot use an unsupported grant_type", async () => {
+      expect.assertions(5);
       const body = new FormData();
       body.set("grant_type", "invalid");
 
@@ -616,63 +638,62 @@ describe("OAuth / POST /oauth/token (Confidential Client)", () => {
         body,
       });
 
-      t.assert.equal(response.status, 400);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(400);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const responseBody = await response.json();
 
-      t.assert.equal(typeof responseBody, "object");
-      t.assert.equal(responseBody.error, "unsupported_grant_type");
-    },
-  );
-
-  // Invalid request
-  it("cannot use unknown parameters", { plan: 4 }, async (t: TestContext) => {
-    const body = new FormData();
-    body.set("grant_type", "client_credentials");
-    body.set("redirect_uri", OOB_REDIRECT_URI);
-
-    const response = await app.request("/oauth/token", {
-      method: "POST",
-      headers: {
-        authorization: basicAuthorization(application),
-      },
-      body,
+      expect(typeof responseBody).toBe("object");
+      expect(Object.keys(responseBody)).toEqual(["error", "error_description"]);
+      expect(responseBody.error).toBe("unsupported_grant_type");
     });
 
-    t.assert.equal(response.status, 400);
-    t.assert.equal(response.headers.get("content-type"), "application/json");
+    // Invalid request
+    it("cannot use unknown parameters", async () => {
+      expect.assertions(4);
+      const body = new FormData();
+      body.set("grant_type", "client_credentials");
+      body.set("redirect_uri", OOB_REDIRECT_URI);
 
-    const responseBody = await response.json();
+      const response = await app.request("/oauth/token", {
+        method: "POST",
+        headers: {
+          authorization: basicAuthorization(application),
+        },
+        body,
+      });
 
-    t.assert.equal(typeof responseBody, "object");
-    t.assert.equal(responseBody.error, "invalid_request");
-  });
-});
+      expect(response.status).toBe(400);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
-describe("OAuth / POST /oauth/token (Public Client)", () => {
-  let application: Schema.Application;
-  let client: Awaited<ReturnType<typeof createOAuthApplication>>;
-  let account: Awaited<ReturnType<typeof createAccount>>;
+      const responseBody = await response.json();
 
-  beforeEach(async () => {
-    account = await createAccount();
-    client = await createOAuthApplication({
-      scopes: ["read:accounts"],
-      redirectUris: [OOB_REDIRECT_URI],
-      confidential: false,
+      expect(typeof responseBody).toBe("object");
+      expect(responseBody.error).toBe("invalid_request");
     });
-    application = await getApplication(client);
   });
 
-  afterEach(async () => {
-    await cleanDatabase();
-  });
+  describe.sequential("OAuth / POST /oauth/token (Public Client)", () => {
+    let application: Schema.Application;
+    let client: Awaited<ReturnType<typeof createOAuthApplication>>;
+    let account: Awaited<ReturnType<typeof createAccount>>;
 
-  it(
-    "can request an access token using the authorization code grant flow",
-    { plan: 8 },
-    async (t: TestContext) => {
+    beforeEach(async () => {
+      account = await createAccount();
+      client = await createOAuthApplication({
+        scopes: ["read:accounts"],
+        redirectUris: [OOB_REDIRECT_URI],
+        confidential: false,
+      });
+      application = await getApplication(client);
+    });
+
+    afterEach(async () => {
+      await cleanDatabase();
+    });
+
+    it("can request an access token using the authorization code grant flow", async () => {
+      expect.assertions(8);
       const accessGrant = await createAccessGrant(
         application.id,
         account.id,
@@ -695,37 +716,23 @@ describe("OAuth / POST /oauth/token (Public Client)", () => {
 
       const responseBody = await response.json();
 
-      t.assert.equal(response.status, 200);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const lastAccessToken = await getLastAccessToken();
       const changedAccessGrant = await findAccessGrant(accessGrant.code);
 
-      t.assert.notEqual(
-        changedAccessGrant.revoked,
-        null,
-        "Successfully revokes the access grant",
-      );
-      t.assert.equal(lastAccessToken.grant_type, "authorization_code");
-      t.assert.deepStrictEqual(
-        lastAccessToken.scopes,
-        changedAccessGrant.scopes,
-      );
+      expect(changedAccessGrant.revoked).not.toBeNull();
+      expect(lastAccessToken.grant_type).toBe("authorization_code");
+      expect(lastAccessToken.scopes).toEqual(changedAccessGrant.scopes);
 
-      t.assert.equal(
-        responseBody.access_token,
-        lastAccessToken.code,
-        "Generates an Access Token",
-      );
-      t.assert.equal(responseBody.token_type, "Bearer");
-      t.assert.equal(responseBody.scope, lastAccessToken.scopes.join(" "));
-    },
-  );
+      expect(responseBody.access_token).toBe(lastAccessToken.code);
+      expect(responseBody.token_type).toBe("Bearer");
+      expect(responseBody.scope).toBe(lastAccessToken.scopes.join(" "));
+    });
 
-  it(
-    "cannot request an access token using the client credentials grant flow",
-    { plan: 3 },
-    async (t: TestContext) => {
+    it("cannot request an access token using the client credentials grant flow", async () => {
+      expect.assertions(3);
       const body = new FormData();
       body.set("grant_type", "client_credentials");
       body.set("scope", "read:accounts");
@@ -740,46 +747,43 @@ describe("OAuth / POST /oauth/token (Public Client)", () => {
 
       const responseBody = await response.json();
 
-      t.assert.equal(response.status, 400);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(400);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
-      t.assert.equal(responseBody.error, "unauthorized_client");
-    },
-  );
-});
-
-describe("OAuth / POST /oauth/revoke", () => {
-  let account: Awaited<ReturnType<typeof createAccount>>;
-  let client: Awaited<ReturnType<typeof createOAuthApplication>>;
-  let application: Schema.Application;
-  let wrongClient: Awaited<ReturnType<typeof createOAuthApplication>>;
-  let wrongApplication: Schema.Application;
-
-  beforeEach(async () => {
-    account = await createAccount();
-    client = await createOAuthApplication({
-      scopes: ["read:accounts"],
-      redirectUris: [OOB_REDIRECT_URI],
-      confidential: true,
+      expect(responseBody.error).toBe("unauthorized_client");
     });
-    application = await getApplication(client);
-
-    wrongClient = await createOAuthApplication({
-      scopes: ["read:accounts"],
-      redirectUris: [OOB_REDIRECT_URI],
-      confidential: true,
-    });
-    wrongApplication = await getApplication(wrongClient);
   });
 
-  afterEach(async () => {
-    await cleanDatabase();
-  });
+  describe.sequential("OAuth / POST /oauth/revoke", () => {
+    let account: Awaited<ReturnType<typeof createAccount>>;
+    let client: Awaited<ReturnType<typeof createOAuthApplication>>;
+    let application: Schema.Application;
+    let wrongClient: Awaited<ReturnType<typeof createOAuthApplication>>;
+    let wrongApplication: Schema.Application;
 
-  it(
-    "can revoke an access token using client_secret_basic",
-    { plan: 4 },
-    async (t: TestContext) => {
+    beforeEach(async () => {
+      account = await createAccount();
+      client = await createOAuthApplication({
+        scopes: ["read:accounts"],
+        redirectUris: [OOB_REDIRECT_URI],
+        confidential: true,
+      });
+      application = await getApplication(client);
+
+      wrongClient = await createOAuthApplication({
+        scopes: ["read:accounts"],
+        redirectUris: [OOB_REDIRECT_URI],
+        confidential: true,
+      });
+      wrongApplication = await getApplication(wrongClient);
+    });
+
+    afterEach(async () => {
+      await cleanDatabase();
+    });
+
+    it("can revoke an access token using client_secret_basic", async () => {
+      expect.assertions(4);
       const accessToken = await getAccessToken(client, account);
       const body = new FormData();
       body.set("token", accessToken.token);
@@ -792,22 +796,19 @@ describe("OAuth / POST /oauth/revoke", () => {
         body,
       });
 
-      t.assert.equal(response.status, 200);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
-      t.assert.equal(response.headers.get("access-control-allow-origin"), "*");
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
 
       const accessTokenAfterRevocation = await findAccessToken(
         accessToken.token,
       );
 
-      t.assert.equal(accessTokenAfterRevocation, undefined);
-    },
-  );
+      expect(accessTokenAfterRevocation).toBe(undefined);
+    });
 
-  it(
-    "can revoke an access token using client_secret_post",
-    { plan: 4 },
-    async (t: TestContext) => {
+    it("can revoke an access token using client_secret_post", async () => {
+      expect.assertions(4);
       const accessToken = await getAccessToken(client, account);
       const body = new FormData();
       body.set("token", accessToken.token);
@@ -819,22 +820,19 @@ describe("OAuth / POST /oauth/revoke", () => {
         body,
       });
 
-      t.assert.equal(response.status, 200);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
-      t.assert.equal(response.headers.get("access-control-allow-origin"), "*");
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
 
       const accessTokenAfterRevocation = await findAccessToken(
         accessToken.token,
       );
 
-      t.assert.equal(accessTokenAfterRevocation, undefined);
-    },
-  );
+      expect(accessTokenAfterRevocation).toBe(undefined);
+    });
 
-  it(
-    "cannot revoke an access token for a different client, but does not return any errors",
-    { plan: 4 },
-    async (t: TestContext) => {
+    it("cannot revoke an access token for a different client, but does not return any errors", async () => {
+      expect.assertions(4);
       const accessToken = await getAccessToken(client, account);
       const body = new FormData();
       body.set("token", accessToken.token);
@@ -846,22 +844,19 @@ describe("OAuth / POST /oauth/revoke", () => {
         body,
       });
 
-      t.assert.equal(response.status, 200);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
-      t.assert.equal(response.headers.get("access-control-allow-origin"), "*");
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
 
       const accessTokenAfterRevocation = await findAccessToken(
         accessToken.token,
       );
 
-      t.assert.notEqual(accessTokenAfterRevocation, undefined);
-    },
-  );
+      expect(accessTokenAfterRevocation).not.toBe(undefined);
+    });
 
-  it(
-    "cannot revoke a token using token_type_hint of refresh_token",
-    { plan: 5 },
-    async (t: TestContext) => {
+    it("cannot revoke a token using token_type_hint of refresh_token", async () => {
+      expect.assertions(5);
       const body = new FormData();
       body.set("token", "123");
       body.set("token_type_hint", "refresh_token");
@@ -874,21 +869,18 @@ describe("OAuth / POST /oauth/revoke", () => {
         body,
       });
 
-      t.assert.equal(response.status, 400);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
-      t.assert.equal(response.headers.get("access-control-allow-origin"), "*");
+      expect(response.status).toBe(400);
+      expect(response.headers.get("content-type")).toBe("application/json");
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
 
       const responseBody = await response.json();
 
-      t.assert.equal(typeof responseBody, "object");
-      t.assert.equal(responseBody.error, "unsupported_token_type");
-    },
-  );
+      expect(typeof responseBody).toBe("object");
+      expect(responseBody.error).toBe("unsupported_token_type");
+    });
 
-  it(
-    "cannot revoke a token without supplying the token parameter",
-    { plan: 5 },
-    async (t: TestContext) => {
+    it("cannot revoke a token without supplying the token parameter", async () => {
+      expect.assertions(5);
       const body = new FormData();
       // explicitly doesn't have `token`
       body.set("token_type_hint", "refresh_token");
@@ -901,14 +893,14 @@ describe("OAuth / POST /oauth/revoke", () => {
         body,
       });
 
-      t.assert.equal(response.status, 400);
-      t.assert.equal(response.headers.get("content-type"), "application/json");
-      t.assert.equal(response.headers.get("access-control-allow-origin"), "*");
+      expect(response.status).toBe(400);
+      expect(response.headers.get("content-type")).toBe("application/json");
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
 
       const responseBody = await response.json();
 
-      t.assert.equal(typeof responseBody, "object");
-      t.assert.equal(responseBody.error, "invalid_request");
-    },
-  );
+      expect(typeof responseBody).toBe("object");
+      expect(responseBody.error).toBe("invalid_request");
+    });
+  });
 });

--- a/src/oauth.tsx
+++ b/src/oauth.tsx
@@ -33,6 +33,8 @@ const logger = getLogger(["hollo", "oauth"]);
 
 const app = new Hono<{ Variables: ClientAuthenticationVariables }>();
 
+/* v8 ignore start */
+
 app.get(
   "/authorize",
   zValidator(
@@ -73,6 +75,8 @@ app.get(
     );
   },
 );
+
+/* v8 ignore stop */
 
 app.post(
   "/authorize",
@@ -223,8 +227,6 @@ app.post("/token", cors(), clientAuthentication, async (c) => {
             );
           }
 
-          /* v8 ignore start */
-          // TODO: The test for this requires time travel
           const notAfter =
             accessGrant.created.valueOf() + accessGrant.expiresIn;
           if (Date.now() > notAfter) {
@@ -236,7 +238,6 @@ app.post("/token", cors(), clientAuthentication, async (c) => {
               400,
             );
           }
-          /* v8 ignore stop */
 
           if (accessGrant.redirectUri !== form.redirect_uri) {
             return c.json(

--- a/src/oauth.tsx
+++ b/src/oauth.tsx
@@ -1,43 +1,38 @@
 import { zValidator } from "@hono/zod-validator";
 import { getLogger } from "@logtape/logtape";
 import { and, eq } from "drizzle-orm";
-import { escape } from "es-toolkit";
 import { type Context, Hono } from "hono";
 import { cors } from "hono/cors";
 import { z } from "zod";
-import { Layout } from "./components/Layout";
-import { db } from "./db";
-import { requestBody } from "./helpers";
-import { loginRequired } from "./login";
-import { OOB_REDIRECT_URI } from "./oauth/constants";
+import { db } from "./db.ts";
+import { requestBody } from "./helpers.ts";
+import { loginRequired } from "./login.ts";
+import { OOB_REDIRECT_URI } from "./oauth/constants.ts";
 import {
   createAccessGrant,
   createAccessToken,
   createClientCredential,
-} from "./oauth/helpers";
+} from "./oauth/helpers.ts";
 import {
   type ClientAuthenticationVariables,
   clientAuthentication,
-} from "./oauth/middleware";
-import { scopesSchema } from "./oauth/validators";
+} from "./oauth/middleware.ts";
+import { scopesSchema } from "./oauth/validators.ts";
 import {
-  type Account,
-  type AccountOwner,
-  type Application,
-  type Scope,
   accessGrants,
   accessTokens,
   applications,
   scopeEnum,
-} from "./schema";
-import { renderCustomEmojis } from "./text";
-import { uuid } from "./uuid";
+} from "./schema.ts";
+import { uuid } from "./uuid.ts";
+
+import { AuthorizationPage } from "./pages/oauth/authorization.tsx";
+import { AuthorizationCodePage } from "./pages/oauth/authorization_code.tsx";
 
 const logger = getLogger(["hollo", "oauth"]);
 
 const app = new Hono<{ Variables: ClientAuthenticationVariables }>();
 
-/* c8 ignore start */
 app.get(
   "/authorize",
   zValidator(
@@ -78,82 +73,6 @@ app.get(
     );
   },
 );
-
-interface AuthorizationPageProps {
-  accountOwners: (AccountOwner & { account: Account })[];
-  application: Application;
-  redirectUri: string;
-  scopes: Scope[];
-  state?: string;
-}
-
-function AuthorizationPage(props: AuthorizationPageProps) {
-  return (
-    <Layout title={`Hollo: Authorize ${props.application.name}`}>
-      <hgroup>
-        <h1>Authorize {props.application.name}</h1>
-        <p>Do you want to authorize this application to access your account?</p>
-      </hgroup>
-      <p>It allows the application to:</p>
-      <ul>
-        {props.scopes.map((scope) => (
-          <li key={scope}>
-            <code>{scope}</code>
-          </li>
-        ))}
-      </ul>
-      <form action="/oauth/authorize" method="post">
-        <p>Choose an account to authorize:</p>
-        {props.accountOwners.map((accountOwner, i) => {
-          const accountName = renderCustomEmojis(
-            escape(accountOwner.account.name),
-            accountOwner.account.emojis,
-          );
-          return (
-            <label>
-              <input
-                type="radio"
-                name="account_id"
-                value={accountOwner.id}
-                checked={i === 0}
-              />
-              {/* biome-ignore lint/security/noDangerouslySetInnerHtml: xss protected */}
-              <strong dangerouslySetInnerHTML={{ __html: accountName }} />
-              <p style="margin-left: 1.75em; margin-top: 0.25em;">
-                <small>{accountOwner.account.handle}</small>
-              </p>
-            </label>
-          );
-        })}
-        <input
-          type="hidden"
-          name="application_id"
-          value={props.application.id}
-        />
-        <input type="hidden" name="redirect_uri" value={props.redirectUri} />
-        <input type="hidden" name="scopes" value={props.scopes.join(" ")} />
-        {props.state != null && (
-          <input type="hidden" name="state" value={props.state} />
-        )}
-        <div role="group">
-          {props.redirectUri !== "urn:ietf:wg:oauth:2.0:oob" && (
-            <button
-              type="submit"
-              class="secondary"
-              name="decision"
-              value="deny"
-            >
-              Deny
-            </button>
-          )}
-          <button type="submit" name="decision" value="allow">
-            Allow
-          </button>
-        </div>
-      </form>
-    </Layout>
-  );
-}
 
 app.post(
   "/authorize",
@@ -226,28 +145,6 @@ app.post(
     return c.redirect(url.href);
   },
 );
-
-interface AuthorizationCodePageProps {
-  application: Application;
-  code: string;
-}
-
-function AuthorizationCodePage(props: AuthorizationCodePageProps) {
-  return (
-    <Layout title={"Hollo: Authorization Code"}>
-      <hgroup>
-        <h1>Authorization Code</h1>
-        <p>Here is your authorization code.</p>
-      </hgroup>
-      <pre>{props.code}</pre>
-      <p>
-        Copy this code and paste it into <em>{props.application.name}</em>.
-      </p>
-    </Layout>
-  );
-}
-
-/* c8 ignore stop */
 
 const INVALID_GRANT_ERROR_DESCRIPTION =
   "The provided authorization code is invalid, expired, revoked, " +
@@ -326,7 +223,7 @@ app.post("/token", cors(), clientAuthentication, async (c) => {
             );
           }
 
-          /* c8 ignore start */
+          /* v8 ignore start */
           // TODO: The test for this requires time travel
           const notAfter =
             accessGrant.created.valueOf() + accessGrant.expiresIn;
@@ -339,7 +236,7 @@ app.post("/token", cors(), clientAuthentication, async (c) => {
               400,
             );
           }
-          /* c8 ignore stop */
+          /* v8 ignore stop */
 
           if (accessGrant.redirectUri !== form.redirect_uri) {
             return c.json(
@@ -362,7 +259,7 @@ app.post("/token", cors(), clientAuthentication, async (c) => {
           // create the access token
           const accessToken = await createAccessToken(accessGrant, tx);
 
-          /* c8 ignore start */
+          /* v8 ignore start */
           // TODO: This scenario requires an insert to the database failing, so not sure how to test:
           if (accessToken === undefined) {
             return c.json(
@@ -374,7 +271,7 @@ app.post("/token", cors(), clientAuthentication, async (c) => {
               500,
             );
           }
-          /* c8 ignore stop */
+          /* v8 ignore stop */
 
           return c.json(
             {
@@ -392,7 +289,7 @@ app.post("/token", cors(), clientAuthentication, async (c) => {
           deferrable: true,
         },
       )
-      /* c8 ignore start */
+      /* v8 ignore start */
       /* I'm not sure how we'd ever test this scenario */
       .catch((err) => {
         logger.error("An unknown error occurred", err);
@@ -406,7 +303,7 @@ app.post("/token", cors(), clientAuthentication, async (c) => {
           500,
         );
       });
-    /* c8 ignore stop */
+    /* v8 ignore stop */
   }
 
   if (form.grant_type === "client_credentials") {

--- a/src/oauth/constants.ts
+++ b/src/oauth/constants.ts
@@ -1,1 +1,6 @@
 export const OOB_REDIRECT_URI = "urn:ietf:wg:oauth:2.0:oob";
+export const ACCESS_GRANT_EXPIRES_IN = 10 * 60 * 1000;
+export const ACCESS_GRANT_DELETE_AFTER = 3600 * 24 * 1000;
+
+export const ACCESS_GRANT_SIZE = 64;
+export const ACCESS_TOKEN_SIZE = 64;

--- a/src/oauth/helpers.ts
+++ b/src/oauth/helpers.ts
@@ -78,7 +78,7 @@ export async function createAccessToken(
     })
     .returning();
 
-  /* c8 ignore start */
+  /* v8 ignore start */
   // This case is only possible if there's some sort of database error, which
   // can't really be tested, unless we mock drizzle somehow?
   if (result.length !== 1) {
@@ -92,7 +92,7 @@ export async function createAccessToken(
 
     return undefined;
   }
-  /* c8 ignore end */
+  /* v8 ignore end */
 
   return {
     token: result[0].code,
@@ -122,7 +122,7 @@ export async function createClientCredential(
     })
     .returning();
 
-  /* c8 ignore start */
+  /* v8 ignore start */
   // This case is only possible if there's some sort of database error, which
   // can't really be tested, unless we mock drizzle somehow?
   //
@@ -133,7 +133,7 @@ export async function createClientCredential(
       "We were unable to create a client credential access token at this time.",
     );
   }
-  /* c8 ignore end */
+  /* v8 ignore end */
 
   return {
     token: result[0].code,

--- a/src/oauth/middleware.test.ts
+++ b/src/oauth/middleware.test.ts
@@ -1,6 +1,5 @@
-import { afterEach, beforeEach, describe, it } from "node:test";
-import type { TestContext } from "node:test";
 import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type * as Schema from "../schema";
 
@@ -15,38 +14,38 @@ import {
 import { createClientCredential } from "./helpers";
 import { type Variables, scopeRequired, tokenRequired } from "./middleware";
 
-describe("OAuth / Middleware / tokenRequired", () => {
-  const app = new Hono<{ Variables: Variables }>();
+describe.sequential("OAuth / Middleware", () => {
+  describe.sequential("tokenRequired", () => {
+    const app = new Hono<{ Variables: Variables }>();
 
-  app.get("/tokenRequired", tokenRequired, (c) => {
-    const token = c.get("token");
-    const authorizationHeader = c.req.header("Authorization");
-    return c.json({
-      ...token,
-      authorizationHeader,
+    app.get("/tokenRequired", tokenRequired, (c) => {
+      const token = c.get("token");
+      const authorizationHeader = c.req.header("Authorization");
+      return c.json({
+        ...token,
+        authorizationHeader,
+      });
     });
-  });
 
-  let application: Schema.Application;
-  let client: Awaited<ReturnType<typeof createOAuthApplication>>;
-  let account: Awaited<ReturnType<typeof createAccount>>;
+    let application: Schema.Application;
+    let client: Awaited<ReturnType<typeof createOAuthApplication>>;
+    let account: Awaited<ReturnType<typeof createAccount>>;
 
-  beforeEach(async () => {
-    account = await createAccount();
-    client = await createOAuthApplication({
-      scopes: ["read:accounts"],
+    beforeEach(async () => {
+      account = await createAccount();
+      client = await createOAuthApplication({
+        scopes: ["read:accounts"],
+      });
+      application = await getApplication(client);
     });
-    application = await getApplication(client);
-  });
 
-  afterEach(async () => {
-    await cleanDatabase();
-  });
+    afterEach(async () => {
+      await cleanDatabase();
+    });
 
-  it(
-    "Can use a client credentials token",
-    { plan: 7 },
-    async (t: TestContext) => {
+    it("Can use a client credentials token", async () => {
+      expect.assertions(7);
+
       const clientCredential = await createClientCredential(application, [
         "read:accounts",
       ]);
@@ -58,55 +57,49 @@ describe("OAuth / Middleware / tokenRequired", () => {
         },
       });
 
-      t.assert.equal(response.status, 200, "Should return 200");
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const json = await response.json();
 
-      t.assert.equal(
-        json.authorizationHeader,
-        `Bearer ${clientCredential.token}`,
-      );
-      t.assert.equal(json.grant_type, "client_credentials");
-      t.assert.equal(json.application.clientId, application.clientId);
-      t.assert.deepStrictEqual(json.scopes, application.scopes);
-      t.assert.strictEqual(
-        json.accountOwner,
-        null,
-        "A client credential grant should not have an account owner",
-      );
-    },
-  );
-
-  it("Can use an access token", { plan: 8 }, async (t: TestContext) => {
-    const accessToken = await getAccessToken(client, account, [
-      "read:accounts",
-    ]);
-
-    const response = await app.request("/tokenRequired", {
-      method: "GET",
-      headers: {
-        authorization: bearerAuthorization(accessToken),
-      },
+      expect(json.authorizationHeader).toBe(`Bearer ${clientCredential.token}`);
+      expect(json.grant_type).toBe("client_credentials");
+      expect(json.application.clientId).toBe(application.clientId);
+      expect(json.scopes).toEqual(application.scopes);
+      // A client credential grant should not have an account owner
+      expect(json.accountOwner).toBeNull();
     });
 
-    t.assert.equal(response.status, 200, "Should return 200");
-    t.assert.equal(response.headers.get("content-type"), "application/json");
+    it("Can use an access token", async () => {
+      expect.assertions(8);
 
-    const json = await response.json();
+      const accessToken = await getAccessToken(client, account, [
+        "read:accounts",
+      ]);
 
-    t.assert.equal(json.authorizationHeader, `Bearer ${accessToken.token}`);
-    t.assert.equal(json.grant_type, "authorization_code");
-    t.assert.equal(json.applicationId, application.id);
-    t.assert.equal(json.accountOwnerId, account.id);
-    t.assert.equal(json.application.clientId, application.clientId);
-    t.assert.deepStrictEqual(json.scopes, application.scopes);
-  });
+      const response = await app.request("/tokenRequired", {
+        method: "GET",
+        headers: {
+          authorization: bearerAuthorization(accessToken),
+        },
+      });
 
-  it(
-    "Returns an error if the client credentials token is not valid",
-    { plan: 3 },
-    async (t: TestContext) => {
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
+
+      const json = await response.json();
+
+      expect(json.authorizationHeader).toBe(`Bearer ${accessToken.token}`);
+      expect(json.grant_type).toBe("authorization_code");
+      expect(json.applicationId).toBe(application.id);
+      expect(json.accountOwnerId).toBe(account.id);
+      expect(json.application.clientId).toBe(application.clientId);
+      expect(json.scopes).toEqual(application.scopes);
+    });
+
+    it("Returns an error if the client credentials token is not valid", async () => {
+      expect.assertions(3);
+
       const response = await app.request("/tokenRequired", {
         method: "GET",
         headers: {
@@ -115,19 +108,17 @@ describe("OAuth / Middleware / tokenRequired", () => {
         },
       });
 
-      t.assert.equal(response.status, 401, "Should return 401");
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(401);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const json = await response.json();
 
-      t.assert.equal(json.error, "invalid_token");
-    },
-  );
+      expect(json.error).toBe("invalid_token");
+    });
 
-  it(
-    "Returns an error if the access token is not valid",
-    { plan: 3 },
-    async (t: TestContext) => {
+    it("Returns an error if the access token is not valid", async () => {
+      expect.assertions(3);
+
       const response = await app.request("/tokenRequired", {
         method: "GET",
         headers: {
@@ -136,19 +127,17 @@ describe("OAuth / Middleware / tokenRequired", () => {
         },
       });
 
-      t.assert.equal(response.status, 401, "Should return 401");
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(401);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const json = await response.json();
 
-      t.assert.equal(json.error, "invalid_token");
-    },
-  );
+      expect(json.error).toBe("invalid_token");
+    });
 
-  it(
-    "Returns an error if Authorization header is not Bearer type",
-    { plan: 3 },
-    async (t: TestContext) => {
+    it("Returns an error if Authorization header is not Bearer type", async () => {
+      expect.assertions(3);
+
       const response = await app.request("/tokenRequired", {
         method: "GET",
         headers: {
@@ -156,19 +145,17 @@ describe("OAuth / Middleware / tokenRequired", () => {
         },
       });
 
-      t.assert.equal(response.status, 401, "Should return 401");
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(401);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const json = await response.json();
 
-      t.assert.equal(json.error, "unauthorized");
-    },
-  );
+      expect(json.error).toBe("unauthorized");
+    });
 
-  it(
-    "Returns an error if Authorization header is not present",
-    { plan: 3 },
-    async (t: TestContext) => {
+    it("Returns an error if Authorization header is not present", async () => {
+      expect.assertions(3);
+
       const response = await app.request("/tokenRequired", {
         method: "GET",
         headers: {
@@ -176,77 +163,77 @@ describe("OAuth / Middleware / tokenRequired", () => {
         },
       });
 
-      t.assert.equal(response.status, 401, "Should return 401");
-      t.assert.equal(response.headers.get("content-type"), "application/json");
+      expect(response.status).toBe(401);
+      expect(response.headers.get("content-type")).toBe("application/json");
 
       const json = await response.json();
 
-      t.assert.equal(json.error, "unauthorized");
-    },
-  );
-});
-
-describe("OAuth / Middleware / scopeRequired", () => {
-  const app = new Hono<{ Variables: Variables }>();
-
-  app.get("/read", tokenRequired, scopeRequired(["read"]), (c) => {
-    const token = c.get("token");
-    const header = c.req.header("Authorization");
-    return c.json({ ...token, header });
+      expect(json.error).toBe("unauthorized");
+    });
   });
 
-  app.get(
-    "/read-blocks",
-    tokenRequired,
-    scopeRequired(["read:blocks"]),
-    (c) => {
+  describe.sequential("scopeRequired", () => {
+    const app = new Hono<{ Variables: Variables }>();
+
+    app.get("/read", tokenRequired, scopeRequired(["read"]), (c) => {
+      const token = c.get("token");
+      const header = c.req.header("Authorization");
+      return c.json({ ...token, header });
+    });
+
+    app.get(
+      "/read-blocks",
+      tokenRequired,
+      scopeRequired(["read:blocks"]),
+      (c) => {
+        const token = c.get("token");
+        const authorizationHeader = c.req.header("Authorization");
+        return c.json({
+          ...token,
+          authorizationHeader,
+        });
+      },
+    );
+
+    app.get("/follow", tokenRequired, scopeRequired(["follow"]), (c) => {
       const token = c.get("token");
       const authorizationHeader = c.req.header("Authorization");
       return c.json({
         ...token,
         authorizationHeader,
       });
-    },
-  );
-
-  app.get("/follow", tokenRequired, scopeRequired(["follow"]), (c) => {
-    const token = c.get("token");
-    const authorizationHeader = c.req.header("Authorization");
-    return c.json({
-      ...token,
-      authorizationHeader,
-    });
-  });
-
-  afterEach(async () => {
-    await cleanDatabase();
-  });
-
-  it("handles requiring read scope", { plan: 2 }, async (t: TestContext) => {
-    const client = await createOAuthApplication({
-      scopes: ["read"],
-    });
-    const application = await getApplication(client);
-
-    const clientCredential = await createClientCredential(application, [
-      "read",
-    ]);
-
-    const response = await app.request("/read", {
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${clientCredential.token}`,
-      },
     });
 
-    t.assert.equal(response.status, 200, "Should return 200");
-    t.assert.equal(response.headers.get("content-type"), "application/json");
-  });
+    afterEach(async () => {
+      await cleanDatabase();
+    });
 
-  it(
-    "handles requiring read:blocks scope",
-    { plan: 2 },
-    async (t: TestContext) => {
+    it("handles requiring read scope", async () => {
+      expect.assertions(2);
+
+      const client = await createOAuthApplication({
+        scopes: ["read"],
+      });
+      const application = await getApplication(client);
+
+      const clientCredential = await createClientCredential(application, [
+        "read",
+      ]);
+
+      const response = await app.request("/read", {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${clientCredential.token}`,
+        },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
+    });
+
+    it("handles requiring read:blocks scope", async () => {
+      expect.assertions(2);
+
       const client = await createOAuthApplication({
         scopes: ["read:blocks"],
       });
@@ -263,15 +250,13 @@ describe("OAuth / Middleware / scopeRequired", () => {
         },
       });
 
-      t.assert.equal(response.status, 200, "Should return 200");
-      t.assert.equal(response.headers.get("content-type"), "application/json");
-    },
-  );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
+    });
 
-  it(
-    "handles requiring read:blocks scope when using read scope",
-    { plan: 2 },
-    async (t: TestContext) => {
+    it("handles requiring read:blocks scope when using read scope", async () => {
+      expect.assertions(2);
+
       const client = await createOAuthApplication({
         scopes: ["read"],
       });
@@ -288,15 +273,13 @@ describe("OAuth / Middleware / scopeRequired", () => {
         },
       });
 
-      t.assert.equal(response.status, 200, "Should return 200");
-      t.assert.equal(response.headers.get("content-type"), "application/json");
-    },
-  );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
+    });
 
-  it(
-    "handles requiring read:blocks scope when using follow scope",
-    { plan: 2 },
-    async (t: TestContext) => {
+    it("handles requiring read:blocks scope when using follow scope", async () => {
+      expect.assertions(2);
+
       const client = await createOAuthApplication({
         scopes: ["follow"],
       });
@@ -313,8 +296,8 @@ describe("OAuth / Middleware / scopeRequired", () => {
         },
       });
 
-      t.assert.equal(response.status, 200, "Should return 200");
-      t.assert.equal(response.headers.get("content-type"), "application/json");
-    },
-  );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
+    });
+  });
 });

--- a/src/oauth/validators.test.ts
+++ b/src/oauth/validators.test.ts
@@ -1,50 +1,49 @@
-import { describe, it } from "node:test";
-import type { TestContext } from "node:test";
+import { describe, expect, it } from "vitest";
 
 import { scopesSchema } from "./validators";
 
 describe("OAuth / Validators", () => {
-  it("can parse a single scope", { plan: 4 }, async (t: TestContext) => {
+  it("can parse a single scope", async () => {
+    expect.assertions(4);
+
     const result = await scopesSchema.safeParseAsync("read");
 
-    t.assert.equal(result.success, true);
-    t.assert.equal(result.error, null);
-    t.assert.ok(Array.isArray(result.data));
-    t.assert.deepStrictEqual(result.data, ["read"]);
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(Array.isArray(result.data)).toBeTruthy();
+    expect(result.data).toEqual(["read"]);
   });
 
-  it("can parse multiple scopes", { plan: 4 }, async (t: TestContext) => {
+  it("can parse multiple scopes", async () => {
+    expect.assertions(4);
+
     const result = await scopesSchema.safeParseAsync("read write");
 
-    t.assert.equal(result.success, true);
-    t.assert.equal(result.error, null);
-    t.assert.ok(Array.isArray(result.data));
-    t.assert.deepStrictEqual(result.data, ["read", "write"]);
+    expect(result.success).toBe(true);
+    expect(result.error).toBeUndefined();
+    expect(Array.isArray(result.data)).toBeTruthy();
+    expect(result.data).toEqual(["read", "write"]);
   });
 
-  it(
-    "returns an error if the scope is invalid",
-    { plan: 4 },
-    async (t: TestContext) => {
-      const result = await scopesSchema.safeParseAsync("invalid");
+  it("returns an error if the scope is invalid", async () => {
+    expect.assertions(4);
 
-      t.assert.equal(result.success, false);
-      t.assert.notEqual(result.error, null);
-      t.assert.equal(result.error?.errors[0].code, "invalid_enum_value");
-      t.assert.ok(!Array.isArray(result.data));
-    },
-  );
+    const result = await scopesSchema.safeParseAsync("invalid");
 
-  it(
-    "returns an error if one of the scopes is invalid",
-    { plan: 4 },
-    async (t: TestContext) => {
-      const result = await scopesSchema.safeParseAsync("read invalid write");
+    expect(result.success).toBe(false);
+    expect(result.error).not.toBeNull();
+    expect(result.error?.errors[0].code).toBe("invalid_enum_value");
+    expect(Array.isArray(result.data)).toBeFalsy();
+  });
 
-      t.assert.equal(result.success, false);
-      t.assert.notEqual(result.error, null);
-      t.assert.equal(result.error?.errors[0].code, "invalid_enum_value");
-      t.assert.ok(!Array.isArray(result.data));
-    },
-  );
+  it("returns an error if one of the scopes is invalid", async () => {
+    expect.assertions(4);
+
+    const result = await scopesSchema.safeParseAsync("read invalid write");
+
+    expect(result.success).toBe(false);
+    expect(result.error).not.toBeNull();
+    expect(result.error?.errors[0].code).toBe("invalid_enum_value");
+    expect(Array.isArray(result.data)).toBeFalsy();
+  });
 });

--- a/src/pages/oauth/authorization.tsx
+++ b/src/pages/oauth/authorization.tsx
@@ -1,0 +1,80 @@
+import { escape } from "es-toolkit";
+import { Layout } from "../../components/Layout";
+import type { Account, AccountOwner, Application, Scope } from "../../schema";
+import { renderCustomEmojis } from "../../text";
+
+interface AuthorizationPageProps {
+  accountOwners: (AccountOwner & { account: Account })[];
+  application: Application;
+  redirectUri: string;
+  scopes: Scope[];
+  state?: string;
+}
+
+export function AuthorizationPage(props: AuthorizationPageProps) {
+  return (
+    <Layout title={`Hollo: Authorize ${props.application.name}`}>
+      <hgroup>
+        <h1>Authorize {props.application.name}</h1>
+        <p>Do you want to authorize this application to access your account?</p>
+      </hgroup>
+      <p>It allows the application to:</p>
+      <ul>
+        {props.scopes.map((scope) => (
+          <li key={scope}>
+            <code>{scope}</code>
+          </li>
+        ))}
+      </ul>
+      <form action="/oauth/authorize" method="post">
+        <p>Choose an account to authorize:</p>
+        {props.accountOwners.map((accountOwner, i) => {
+          const accountName = renderCustomEmojis(
+            escape(accountOwner.account.name),
+            accountOwner.account.emojis,
+          );
+          return (
+            <label>
+              <input
+                type="radio"
+                name="account_id"
+                value={accountOwner.id}
+                checked={i === 0}
+              />
+              {/* biome-ignore lint/security/noDangerouslySetInnerHtml: xss protected */}
+              <strong dangerouslySetInnerHTML={{ __html: accountName }} />
+              <p style="margin-left: 1.75em; margin-top: 0.25em;">
+                <small>{accountOwner.account.handle}</small>
+              </p>
+            </label>
+          );
+        })}
+        <input
+          type="hidden"
+          name="application_id"
+          value={props.application.id}
+        />
+        <input type="hidden" name="redirect_uri" value={props.redirectUri} />
+        <input type="hidden" name="scopes" value={props.scopes.join(" ")} />
+        {props.state != null && (
+          <input type="hidden" name="state" value={props.state} />
+        )}
+        <div role="group">
+          {props.redirectUri !== "urn:ietf:wg:oauth:2.0:oob" && (
+            <button
+              type="submit"
+              class="secondary"
+              name="decision"
+              value="deny"
+            >
+              Deny
+            </button>
+          )}
+          <button type="submit" name="decision" value="allow">
+            Allow
+          </button>
+        </div>
+      </form>
+    </Layout>
+  );
+}

--- a/src/pages/oauth/authorization_code.tsx
+++ b/src/pages/oauth/authorization_code.tsx
@@ -1,0 +1,22 @@
+import { Layout } from "../../components/Layout";
+import type { Application } from "../../schema";
+
+interface AuthorizationCodePageProps {
+  application: Application;
+  code: string;
+}
+
+export function AuthorizationCodePage(props: AuthorizationCodePageProps) {
+  return (
+    <Layout title={"Hollo: Authorization Code"}>
+      <hgroup>
+        <h1>Authorization Code</h1>
+        <p>Here is your authorization code.</p>
+      </hgroup>
+      <pre>{props.code}</pre>
+      <p>
+        Copy this code and paste it into <em>{props.application.name}</em>.
+      </p>
+    </Layout>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noPropertyAccessFromIndexSignature": true
+    "noPropertyAccessFromIndexSignature": false
   },
   "exclude": ["node_modules", "docs"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig(() => ({
   test: {
     env: env,
     reporters: process.env.GITHUB_ACTIONS
-      ? ["basic", "github-actions"]
+      ? ["default", "github-actions"]
       : ["default"],
     fileParallelism: false,
     expect: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,9 +3,9 @@ import { join } from "node:path";
 import { parse } from "dotenv";
 import { defineConfig } from "vitest/config";
 
-const env = parse(await readFile(join(process.cwd(), ".env.test")));
-
-console.log(env);
+const env = parse(
+  await readFile(join(process.cwd(), ".env.test"), { encoding: "utf-8" }),
+);
 
 export default defineConfig(() => ({
   test: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,21 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { parse } from "dotenv";
+import { defineConfig } from "vitest/config";
+
+const env = parse(await readFile(join(process.cwd(), ".env.test")));
+
+console.log(env);
+
+export default defineConfig(() => ({
+  test: {
+    env: env,
+    reporters: process.env.GITHUB_ACTIONS
+      ? ["basic", "github-actions"]
+      : ["default"],
+    fileParallelism: false,
+    expect: {
+      requireAssertions: true,
+    },
+  },
+}));


### PR DESCRIPTION
c8 was giving misleading coverage reports for files containing jsx, which made assessing where we were at with test coverage difficult.

I also tried using nyc, one-double-zero and borp, but all these didn't work or give good results either.

This does mean we're no longer using `node:test`, and I have encountered some issues in watch mode with database deadlocks that don't normally occur in full runs, so I think vitest may not always be running sequentially.