### PR TITLE
Feat: Add profile scope + userinfo endpoint + profile scope for /api/v1/accounts/verify_credentials

### DIFF
--- a/drizzle/0068_add_profile_scope.sql
+++ b/drizzle/0068_add_profile_scope.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."scope" ADD VALUE 'profile';

--- a/drizzle/meta/0068_snapshot.json
+++ b/drizzle/meta/0068_snapshot.json
@@ -1,0 +1,3008 @@
+{
+  "id": "0fb599d7-1e9d-44ce-8b5c-c13b3f9592c4",
+  "prevId": "b650b966-a711-465e-8974-9106fca98094",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.access_grants": {
+      "name": "access_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_in": {
+          "name": "expires_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "scope[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "code_challenge_method": {
+          "name": "code_challenge_method",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_owner_id": {
+          "name": "resource_owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "revoked": {
+          "name": "revoked",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "access_grants_resource_owner_id_index": {
+          "name": "access_grants_resource_owner_id_index",
+          "columns": [
+            {
+              "expression": "resource_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "access_grants_application_id_applications_id_fk": {
+          "name": "access_grants_application_id_applications_id_fk",
+          "tableFrom": "access_grants",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "access_grants_resource_owner_id_account_owners_id_fk": {
+          "name": "access_grants_resource_owner_id_account_owners_id_fk",
+          "tableFrom": "access_grants",
+          "tableTo": "account_owners",
+          "columnsFrom": [
+            "resource_owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "access_grants_code_unique": {
+          "name": "access_grants_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.access_tokens": {
+      "name": "access_tokens",
+      "schema": "",
+      "columns": {
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_owner_id": {
+          "name": "account_owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grant_type": {
+          "name": "grant_type",
+          "type": "grant_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'authorization_code'"
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "scope[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "access_tokens_application_id_applications_id_fk": {
+          "name": "access_tokens_application_id_applications_id_fk",
+          "tableFrom": "access_tokens",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "access_tokens_account_owner_id_account_owners_id_fk": {
+          "name": "access_tokens_account_owner_id_account_owners_id_fk",
+          "tableFrom": "access_tokens",
+          "tableTo": "account_owners",
+          "columnsFrom": [
+            "account_owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.account_owners": {
+      "name": "account_owners",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rsa_private_key_jwk": {
+          "name": "rsa_private_key_jwk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rsa_public_key_jwk": {
+          "name": "rsa_public_key_jwk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ed25519_private_key_jwk": {
+          "name": "ed25519_private_key_jwk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ed25519_public_key_jwk": {
+          "name": "ed25519_public_key_jwk",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fields": {
+          "name": "fields",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "bio": {
+          "name": "bio",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "followed_tags": {
+          "name": "followed_tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "post_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "discoverable": {
+          "name": "discoverable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "theme_color": {
+          "name": "theme_color",
+          "type": "theme_color",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_owners_id_accounts_id_fk": {
+          "name": "account_owners_id_accounts_id_fk",
+          "tableFrom": "account_owners",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "account_owners_handle_unique": {
+          "name": "account_owners_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iri": {
+          "name": "iri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "account_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "handle": {
+          "name": "handle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bio_html": {
+          "name": "bio_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "protected": {
+          "name": "protected",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "inbox_url": {
+          "name": "inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "followers_url": {
+          "name": "followers_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shared_inbox_url": {
+          "name": "shared_inbox_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "featured_url": {
+          "name": "featured_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "following_count": {
+          "name": "following_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "followers_count": {
+          "name": "followers_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "posts_count": {
+          "name": "posts_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "field_htmls": {
+          "name": "field_htmls",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::json"
+        },
+        "emojis": {
+          "name": "emojis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "sensitive": {
+          "name": "sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "successor_id": {
+          "name": "successor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aliases": {
+          "name": "aliases",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "(ARRAY[]::text[])"
+        },
+        "instance_host": {
+          "name": "instance_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_successor_id_accounts_id_fk": {
+          "name": "accounts_successor_id_accounts_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "successor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "accounts_instance_host_instances_host_fk": {
+          "name": "accounts_instance_host_instances_host_fk",
+          "tableFrom": "accounts",
+          "tableTo": "instances",
+          "columnsFrom": [
+            "instance_host"
+          ],
+          "columnsTo": [
+            "host"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "accounts_iri_unique": {
+          "name": "accounts_iri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iri"
+          ]
+        },
+        "accounts_handle_unique": {
+          "name": "accounts_handle_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "handle"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.applications": {
+      "name": "applications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "scope[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidential": {
+          "name": "confidential",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "applications_client_id_unique": {
+          "name": "applications_client_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "client_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blocked_account_id": {
+          "name": "blocked_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "blocks_account_id_index": {
+          "name": "blocks_account_id_index",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "blocks_blocked_account_id_index": {
+          "name": "blocks_blocked_account_id_index",
+          "columns": [
+            {
+              "expression": "blocked_account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocks_account_id_accounts_id_fk": {
+          "name": "blocks_account_id_accounts_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "blocks_blocked_account_id_accounts_id_fk": {
+          "name": "blocks_blocked_account_id_accounts_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "blocked_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blocks_account_id_blocked_account_id_pk": {
+          "name": "blocks_account_id_blocked_account_id_pk",
+          "columns": [
+            "account_id",
+            "blocked_account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bookmarks": {
+      "name": "bookmarks",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_owner_id": {
+          "name": "account_owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "bookmarks_post_id_account_owner_id_index": {
+          "name": "bookmarks_post_id_account_owner_id_index",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bookmarks_post_id_posts_id_fk": {
+          "name": "bookmarks_post_id_posts_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bookmarks_account_owner_id_account_owners_id_fk": {
+          "name": "bookmarks_account_owner_id_account_owners_id_fk",
+          "tableFrom": "bookmarks",
+          "tableTo": "account_owners",
+          "columnsFrom": [
+            "account_owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bookmarks_post_id_account_owner_id_pk": {
+          "name": "bookmarks_post_id_account_owner_id_pk",
+          "columns": [
+            "post_id",
+            "account_owner_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credentials": {
+      "name": "credentials",
+      "schema": "",
+      "columns": {
+        "email": {
+          "name": "email",
+          "type": "varchar(254)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.custom_emojis": {
+      "name": "custom_emojis",
+      "schema": "",
+      "columns": {
+        "shortcode": {
+          "name": "shortcode",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.featured_tags": {
+      "name": "featured_tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_owner_id": {
+          "name": "account_owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "featured_tags_account_owner_id_account_owners_id_fk": {
+          "name": "featured_tags_account_owner_id_account_owners_id_fk",
+          "tableFrom": "featured_tags",
+          "tableTo": "account_owners",
+          "columnsFrom": [
+            "account_owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "featured_tags_account_owner_id_name_unique": {
+          "name": "featured_tags_account_owner_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "account_owner_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follows": {
+      "name": "follows",
+      "schema": "",
+      "columns": {
+        "iri": {
+          "name": "iri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "following_id": {
+          "name": "following_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "follower_id": {
+          "name": "follower_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shares": {
+          "name": "shares",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify": {
+          "name": "notify",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "languages": {
+          "name": "languages",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "approved": {
+          "name": "approved",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "follows_following_id_accounts_id_fk": {
+          "name": "follows_following_id_accounts_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "following_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "follows_follower_id_accounts_id_fk": {
+          "name": "follows_follower_id_accounts_id_fk",
+          "tableFrom": "follows",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "follower_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "follows_following_id_follower_id_pk": {
+          "name": "follows_following_id_follower_id_pk",
+          "columns": [
+            "following_id",
+            "follower_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "follows_iri_unique": {
+          "name": "follows_iri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "ck_follows_self": {
+          "name": "ck_follows_self",
+          "value": "\"follows\".\"following_id\" != \"follows\".\"follower_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.instances": {
+      "name": "instances",
+      "schema": "",
+      "columns": {
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "software": {
+          "name": "software",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "software_version": {
+          "name": "software_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.likes": {
+      "name": "likes",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "likes_account_id_post_id_index": {
+          "name": "likes_account_id_post_id_index",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "likes_post_id_posts_id_fk": {
+          "name": "likes_post_id_posts_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "likes_account_id_accounts_id_fk": {
+          "name": "likes_account_id_accounts_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "likes_post_id_account_id_pk": {
+          "name": "likes_post_id_account_id_pk",
+          "columns": [
+            "post_id",
+            "account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_members": {
+      "name": "list_members",
+      "schema": "",
+      "columns": {
+        "list_id": {
+          "name": "list_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "list_members_list_id_lists_id_fk": {
+          "name": "list_members_list_id_lists_id_fk",
+          "tableFrom": "list_members",
+          "tableTo": "lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_members_account_id_accounts_id_fk": {
+          "name": "list_members_account_id_accounts_id_fk",
+          "tableFrom": "list_members",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "list_members_list_id_account_id_pk": {
+          "name": "list_members_list_id_account_id_pk",
+          "columns": [
+            "list_id",
+            "account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.list_posts": {
+      "name": "list_posts",
+      "schema": "",
+      "columns": {
+        "list_id": {
+          "name": "list_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "list_posts_list_id_post_id_index": {
+          "name": "list_posts_list_id_post_id_index",
+          "columns": [
+            {
+              "expression": "list_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "list_posts_list_id_lists_id_fk": {
+          "name": "list_posts_list_id_lists_id_fk",
+          "tableFrom": "list_posts",
+          "tableTo": "lists",
+          "columnsFrom": [
+            "list_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "list_posts_post_id_posts_id_fk": {
+          "name": "list_posts_post_id_posts_id_fk",
+          "tableFrom": "list_posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "list_posts_list_id_post_id_pk": {
+          "name": "list_posts_list_id_post_id_pk",
+          "columns": [
+            "list_id",
+            "post_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lists": {
+      "name": "lists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_owner_id": {
+          "name": "account_owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "replies_policy": {
+          "name": "replies_policy",
+          "type": "list_replies_policy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'list'"
+        },
+        "exclusive": {
+          "name": "exclusive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "lists_account_owner_id_account_owners_id_fk": {
+          "name": "lists_account_owner_id_account_owners_id_fk",
+          "tableFrom": "lists",
+          "tableTo": "account_owners",
+          "columnsFrom": [
+            "account_owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.markers": {
+      "name": "markers",
+      "schema": "",
+      "columns": {
+        "account_owner_id": {
+          "name": "account_owner_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "marker_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_read_id": {
+          "name": "last_read_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "markers_account_owner_id_account_owners_id_fk": {
+          "name": "markers_account_owner_id_account_owners_id_fk",
+          "tableFrom": "markers",
+          "tableTo": "account_owners",
+          "columnsFrom": [
+            "account_owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "markers_account_owner_id_type_pk": {
+          "name": "markers_account_owner_id_type_pk",
+          "columns": [
+            "account_owner_id",
+            "type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_type": {
+          "name": "thumbnail_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_url": {
+          "name": "thumbnail_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_width": {
+          "name": "thumbnail_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thumbnail_height": {
+          "name": "thumbnail_height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "media_post_id_index": {
+          "name": "media_post_id_index",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "media_post_id_posts_id_fk": {
+          "name": "media_post_id_posts_id_fk",
+          "tableFrom": "media",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mentions": {
+      "name": "mentions",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mentions_post_id_account_id_index": {
+          "name": "mentions_post_id_account_id_index",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mentions_post_id_posts_id_fk": {
+          "name": "mentions_post_id_posts_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mentions_account_id_accounts_id_fk": {
+          "name": "mentions_account_id_accounts_id_fk",
+          "tableFrom": "mentions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "mentions_post_id_account_id_pk": {
+          "name": "mentions_post_id_account_id_pk",
+          "columns": [
+            "post_id",
+            "account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mutes": {
+      "name": "mutes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "muted_account_id": {
+          "name": "muted_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notifications": {
+          "name": "notifications",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "interval",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mutes_account_id_accounts_id_fk": {
+          "name": "mutes_account_id_accounts_id_fk",
+          "tableFrom": "mutes",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "mutes_muted_account_id_accounts_id_fk": {
+          "name": "mutes_muted_account_id_accounts_id_fk",
+          "tableFrom": "mutes",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "muted_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mutes_account_id_muted_account_id_unique": {
+          "name": "mutes_account_id_muted_account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "account_id",
+            "muted_account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pinned_posts": {
+      "name": "pinned_posts",
+      "schema": "",
+      "columns": {
+        "index": {
+          "name": "index",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "pinned_posts_account_id_post_id_index": {
+          "name": "pinned_posts_account_id_post_id_index",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pinned_posts_account_id_accounts_id_fk": {
+          "name": "pinned_posts_account_id_accounts_id_fk",
+          "tableFrom": "pinned_posts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pinned_posts_post_id_account_id_posts_id_actor_id_fk": {
+          "name": "pinned_posts_post_id_account_id_posts_id_actor_id_fk",
+          "tableFrom": "pinned_posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id",
+            "account_id"
+          ],
+          "columnsTo": [
+            "id",
+            "actor_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pinned_posts_post_id_account_id_unique": {
+          "name": "pinned_posts_post_id_account_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "post_id",
+            "account_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_options": {
+      "name": "poll_options",
+      "schema": "",
+      "columns": {
+        "poll_id": {
+          "name": "poll_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "index": {
+          "name": "index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "votes_count": {
+          "name": "votes_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "poll_options_poll_id_index_index": {
+          "name": "poll_options_poll_id_index_index",
+          "columns": [
+            {
+              "expression": "poll_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "index",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "poll_options_poll_id_polls_id_fk": {
+          "name": "poll_options_poll_id_polls_id_fk",
+          "tableFrom": "poll_options",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "poll_options_poll_id_index_pk": {
+          "name": "poll_options_poll_id_index_pk",
+          "columns": [
+            "poll_id",
+            "index"
+          ]
+        }
+      },
+      "uniqueConstraints": {
+        "poll_options_poll_id_title_unique": {
+          "name": "poll_options_poll_id_title_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "poll_id",
+            "title"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.poll_votes": {
+      "name": "poll_votes",
+      "schema": "",
+      "columns": {
+        "poll_id": {
+          "name": "poll_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "option_index": {
+          "name": "option_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "poll_votes_poll_id_account_id_index": {
+          "name": "poll_votes_poll_id_account_id_index",
+          "columns": [
+            {
+              "expression": "poll_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "poll_votes_poll_id_polls_id_fk": {
+          "name": "poll_votes_poll_id_polls_id_fk",
+          "tableFrom": "poll_votes",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "poll_votes_account_id_accounts_id_fk": {
+          "name": "poll_votes_account_id_accounts_id_fk",
+          "tableFrom": "poll_votes",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "poll_votes_poll_id_option_index_poll_options_poll_id_index_fk": {
+          "name": "poll_votes_poll_id_option_index_poll_options_poll_id_index_fk",
+          "tableFrom": "poll_votes",
+          "tableTo": "poll_options",
+          "columnsFrom": [
+            "poll_id",
+            "option_index"
+          ],
+          "columnsTo": [
+            "poll_id",
+            "index"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "poll_votes_poll_id_option_index_account_id_pk": {
+          "name": "poll_votes_poll_id_option_index_account_id_pk",
+          "columns": [
+            "poll_id",
+            "option_index",
+            "account_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.polls": {
+      "name": "polls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "multiple": {
+          "name": "multiple",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "voters_count": {
+          "name": "voters_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.posts": {
+      "name": "posts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iri": {
+          "name": "iri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "post_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "application_id": {
+          "name": "application_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reply_target_id": {
+          "name": "reply_target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sharing_id": {
+          "name": "sharing_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quote_target_id": {
+          "name": "quote_target_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "post_visibility",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_html": {
+          "name": "content_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_id": {
+          "name": "poll_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "emojis": {
+          "name": "emojis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "sensitive": {
+          "name": "sensitive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preview_card": {
+          "name": "preview_card",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replies_count": {
+          "name": "replies_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "shares_count": {
+          "name": "shares_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "likes_count": {
+          "name": "likes_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "idempotence_key": {
+          "name": "idempotence_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published": {
+          "name": "published",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated": {
+          "name": "updated",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "posts_sharing_id_index": {
+          "name": "posts_sharing_id_index",
+          "columns": [
+            {
+              "expression": "sharing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_actor_id_index": {
+          "name": "posts_actor_id_index",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_actor_id_sharing_id_index": {
+          "name": "posts_actor_id_sharing_id_index",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sharing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_reply_target_id_index": {
+          "name": "posts_reply_target_id_index",
+          "columns": [
+            {
+              "expression": "reply_target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_visibility_actor_id_index": {
+          "name": "posts_visibility_actor_id_index",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_visibility_actor_id_sharing_id_index": {
+          "name": "posts_visibility_actor_id_sharing_id_index",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sharing_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"posts\".\"sharing_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "posts_visibility_actor_id_reply_target_id_index": {
+          "name": "posts_visibility_actor_id_reply_target_id_index",
+          "columns": [
+            {
+              "expression": "visibility",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reply_target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"posts\".\"reply_target_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "posts_actor_id_accounts_id_fk": {
+          "name": "posts_actor_id_accounts_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_application_id_applications_id_fk": {
+          "name": "posts_application_id_applications_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "applications",
+          "columnsFrom": [
+            "application_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_reply_target_id_posts_id_fk": {
+          "name": "posts_reply_target_id_posts_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "reply_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_sharing_id_posts_id_fk": {
+          "name": "posts_sharing_id_posts_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "sharing_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "posts_quote_target_id_posts_id_fk": {
+          "name": "posts_quote_target_id_posts_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "quote_target_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "posts_poll_id_polls_id_fk": {
+          "name": "posts_poll_id_polls_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "polls",
+          "columnsFrom": [
+            "poll_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "posts_iri_unique": {
+          "name": "posts_iri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iri"
+          ]
+        },
+        "posts_id_actor_id_unique": {
+          "name": "posts_id_actor_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "actor_id"
+          ]
+        },
+        "posts_poll_id_unique": {
+          "name": "posts_poll_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "poll_id"
+          ]
+        },
+        "posts_actor_id_sharing_id_unique": {
+          "name": "posts_actor_id_sharing_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "actor_id",
+            "sharing_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reactions": {
+      "name": "reactions",
+      "schema": "",
+      "columns": {
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_emoji": {
+          "name": "custom_emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji_iri": {
+          "name": "emoji_iri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "reactions_post_id_index": {
+          "name": "reactions_post_id_index",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "reactions_post_id_account_id_index": {
+          "name": "reactions_post_id_account_id_index",
+          "columns": [
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "reactions_post_id_posts_id_fk": {
+          "name": "reactions_post_id_posts_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reactions_account_id_accounts_id_fk": {
+          "name": "reactions_account_id_accounts_id_fk",
+          "tableFrom": "reactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "reactions_post_id_account_id_emoji_pk": {
+          "name": "reactions_post_id_account_id_emoji_pk",
+          "columns": [
+            "post_id",
+            "account_id",
+            "emoji"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "iri": {
+          "name": "iri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_account_id": {
+          "name": "target_account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "posts": {
+          "name": "posts",
+          "type": "uuid[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::uuid[]"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reports_account_id_accounts_id_fk": {
+          "name": "reports_account_id_accounts_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "reports_target_account_id_accounts_id_fk": {
+          "name": "reports_target_account_id_accounts_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "target_account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "reports_iri_unique": {
+          "name": "reports_iri_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "iri"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.timeline_posts": {
+      "name": "timeline_posts",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "timeline_posts_account_id_post_id_index": {
+          "name": "timeline_posts_account_id_post_id_index",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "post_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "timeline_posts_account_id_account_owners_id_fk": {
+          "name": "timeline_posts_account_id_account_owners_id_fk",
+          "tableFrom": "timeline_posts",
+          "tableTo": "account_owners",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "timeline_posts_post_id_posts_id_fk": {
+          "name": "timeline_posts_post_id_posts_id_fk",
+          "tableFrom": "timeline_posts",
+          "tableTo": "posts",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "timeline_posts_account_id_post_id_pk": {
+          "name": "timeline_posts_account_id_post_id_pk",
+          "columns": [
+            "account_id",
+            "post_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.totps": {
+      "name": "totps",
+      "schema": "",
+      "columns": {
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "algorithm": {
+          "name": "algorithm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "digits": {
+          "name": "digits",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created": {
+          "name": "created",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_type": {
+      "name": "account_type",
+      "schema": "public",
+      "values": [
+        "Application",
+        "Group",
+        "Organization",
+        "Person",
+        "Service"
+      ]
+    },
+    "public.grant_type": {
+      "name": "grant_type",
+      "schema": "public",
+      "values": [
+        "authorization_code",
+        "client_credentials"
+      ]
+    },
+    "public.list_replies_policy": {
+      "name": "list_replies_policy",
+      "schema": "public",
+      "values": [
+        "followed",
+        "list",
+        "none"
+      ]
+    },
+    "public.marker_type": {
+      "name": "marker_type",
+      "schema": "public",
+      "values": [
+        "notifications",
+        "home"
+      ]
+    },
+    "public.post_type": {
+      "name": "post_type",
+      "schema": "public",
+      "values": [
+        "Article",
+        "Note",
+        "Question"
+      ]
+    },
+    "public.post_visibility": {
+      "name": "post_visibility",
+      "schema": "public",
+      "values": [
+        "public",
+        "unlisted",
+        "private",
+        "direct"
+      ]
+    },
+    "public.scope": {
+      "name": "scope",
+      "schema": "public",
+      "values": [
+        "read",
+        "read:accounts",
+        "read:blocks",
+        "read:bookmarks",
+        "read:favourites",
+        "read:filters",
+        "read:follows",
+        "read:lists",
+        "read:mutes",
+        "read:notifications",
+        "read:search",
+        "read:statuses",
+        "write",
+        "write:accounts",
+        "write:blocks",
+        "write:bookmarks",
+        "write:conversations",
+        "write:favourites",
+        "write:filters",
+        "write:follows",
+        "write:lists",
+        "write:media",
+        "write:mutes",
+        "write:notifications",
+        "write:reports",
+        "write:statuses",
+        "follow",
+        "push",
+        "profile"
+      ]
+    },
+    "public.theme_color": {
+      "name": "theme_color",
+      "schema": "public",
+      "values": [
+        "amber",
+        "azure",
+        "blue",
+        "cyan",
+        "fuchsia",
+        "green",
+        "grey",
+        "indigo",
+        "jade",
+        "lime",
+        "orange",
+        "pink",
+        "pumpkin",
+        "purple",
+        "red",
+        "sand",
+        "slate",
+        "violet",
+        "yellow",
+        "zinc"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -477,6 +477,13 @@
       "when": 1748209114780,
       "tag": "0067_add_pkce_to_access_grants",
       "breakpoints": true
+    },
+    {
+      "idx": 68,
+      "version": "7",
+      "when": 1748827411086,
+      "tag": "0068_add_profile_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/src/api/v1/accounts.ts
+++ b/src/api/v1/accounts.ts
@@ -68,7 +68,7 @@ const allowedImageMimeTypes = ["image/gif", "image/jpeg", "image/png"];
 app.get(
   "/verify_credentials",
   tokenRequired,
-  scopeRequired(["read:accounts"]),
+  scopeRequired(["read:accounts", "profile"]),
   async (c) => {
     const accountOwner = c.get("token").accountOwner;
     if (accountOwner == null) {

--- a/src/api/v1/apps.test.ts
+++ b/src/api/v1/apps.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { cleanDatabase } from "../../../tests/helpers";
 
@@ -18,7 +18,7 @@ import { OOB_REDIRECT_URI } from "../../oauth/constants";
 import type * as Schema from "../../schema";
 
 describe.sequential("POST /api/v1/apps", () => {
-  afterEach(async () => {
+  beforeEach(async () => {
     await cleanDatabase();
   });
 
@@ -281,16 +281,14 @@ describe.sequential("GET /api/v1/apps/verify_credentials", () => {
   let account: Awaited<ReturnType<typeof createAccount>>;
 
   beforeEach(async () => {
+    await cleanDatabase();
+
     account = await createAccount();
     client = await createOAuthApplication({
       scopes: ["read:accounts"],
       confidential: true,
     });
     application = await getApplication(client);
-  });
-
-  afterEach(async () => {
-    await cleanDatabase();
   });
 
   async function actsLikeAnApplicationResponse(response: Response) {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+
+import app from "./index";
+
+describe("Router", () => {
+  describe("CORS Policy", () => {
+    // Note: The API CORS Policy is defined in src/api/index.ts
+
+    it("returns CORS headers on /.well-known/oauth-authorization-server", async () => {
+      expect.assertions(4);
+
+      const response = await app.request(
+        "/.well-known/oauth-authorization-server",
+        {
+          method: "OPTIONS",
+        },
+      );
+
+      expect(response.headers.has("access-control-allow-origin")).toBeTruthy();
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
+
+      expect(response.headers.has("access-control-allow-methods")).toBeTruthy();
+      expect(response.headers.get("access-control-allow-methods")).toBe("GET");
+    });
+
+    it("returns CORS headers on /nodeinfo/2.1", async () => {
+      expect.assertions(4);
+
+      const response = await app.request("/nodeinfo/2.1", {
+        method: "OPTIONS",
+      });
+
+      expect(response.headers.has("access-control-allow-origin")).toBeTruthy();
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
+
+      expect(response.headers.has("access-control-allow-methods")).toBeTruthy();
+      expect(response.headers.get("access-control-allow-methods")).toBe("GET");
+    });
+
+    it("does not return CORS headers on /oauth/authorize", async () => {
+      expect.assertions(2);
+
+      const response = await app.request("/oauth/authorize", {
+        method: "OPTIONS",
+      });
+
+      expect(response.headers.has("access-control-allow-origin")).toBeFalsy();
+      expect(response.headers.has("access-control-allow-methods")).toBeFalsy();
+    });
+
+    it("returns CORS headers on /oauth/token", async () => {
+      expect.assertions(4);
+
+      const response = await app.request("/oauth/token", {
+        method: "OPTIONS",
+      });
+
+      expect(response.headers.has("access-control-allow-origin")).toBeTruthy();
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
+
+      expect(response.headers.has("access-control-allow-methods")).toBeTruthy();
+      expect(response.headers.get("access-control-allow-methods")).toBe("POST");
+    });
+
+    it("returns CORS headers on /oauth/revoke", async () => {
+      expect.assertions(4);
+
+      const response = await app.request("/oauth/revoke", {
+        method: "OPTIONS",
+      });
+
+      expect(response.headers.has("access-control-allow-origin")).toBeTruthy();
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
+
+      expect(response.headers.has("access-control-allow-methods")).toBeTruthy();
+      expect(response.headers.get("access-control-allow-methods")).toBe("POST");
+    });
+
+    it("returns CORS headers on GET /oauth/userinfo", async () => {
+      expect.assertions(4);
+
+      const response = await app.request("/oauth/userinfo", {
+        method: "OPTIONS",
+      });
+
+      expect(response.headers.has("access-control-allow-origin")).toBeTruthy();
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
+
+      expect(response.headers.has("access-control-allow-methods")).toBeTruthy();
+      expect(response.headers.get("access-control-allow-methods")).toBe(
+        "GET,POST",
+      );
+    });
+  });
+});

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -50,8 +50,7 @@ const CorsPolicy = (allowMethods: string[]) =>
 app.use("/.well-known/*", CorsPolicy(["GET"]));
 app.use("/nodeinfo/*", CorsPolicy(["GET"]));
 app.use("/oauth/token", CorsPolicy(["POST"]));
-// Hollo doesn't support token revocation currently:
-// app.use("/oauth/revoke", CorsPolicy(["POST"]));
+app.use("/oauth/revoke", CorsPolicy(["POST"]));
 app.use("/oauth/userinfo", CorsPolicy(["GET", "POST"]));
 
 app.route("/.well-known/oauth-authorization-server", oauthMetadataEndpoint);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,8 @@ import { cors } from "hono/cors";
 import api from "./api";
 import fedi from "./federation";
 import image from "./image";
-import oauth, { oauthAuthorizationServer } from "./oauth";
+import oauth from "./oauth";
+import oauthMetadataEndpoint from "./oauth/endpoints/metadata";
 import pages from "./pages";
 import { DRIVE_DISK, FS_STORAGE_PATH } from "./storage";
 
@@ -53,6 +54,8 @@ app.use("/oauth/token", CorsPolicy(["POST"]));
 // app.use("/oauth/revoke", CorsPolicy(["POST"]));
 app.use("/oauth/userinfo", CorsPolicy(["GET", "POST"]));
 
+app.route("/.well-known/oauth-authorization-server", oauthMetadataEndpoint);
+
 app.use(federation(fedi, (_) => undefined));
 
 app.route("/", pages);
@@ -60,7 +63,6 @@ app.route("/oauth", oauth);
 app.route("/api", api);
 app.route("/image", image);
 
-app.get("/.well-known/oauth-authorization-server", oauthAuthorizationServer);
 app.get("/nodeinfo/2.0", (c) => c.redirect("/nodeinfo/2.1"));
 
 export default app;

--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -1,6 +1,6 @@
 import { parseHTML } from "linkedom";
 import * as timekeeper from "timekeeper";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import app from "./index";
 import type * as Schema from "./schema";
@@ -38,6 +38,8 @@ describe.sequential("OAuth", () => {
     let account: Awaited<ReturnType<typeof createAccount>>;
 
     beforeEach(async () => {
+      await cleanDatabase();
+
       account = await createAccount();
       client = await createOAuthApplication({
         scopes: ["read", "read:accounts", "follow"],
@@ -45,10 +47,6 @@ describe.sequential("OAuth", () => {
         confidential: true,
       });
       application = await getApplication(client);
-    });
-
-    afterEach(async () => {
-      await cleanDatabase();
     });
 
     it("successfully displays an authorization page", async () => {
@@ -547,6 +545,8 @@ describe.sequential("OAuth", () => {
     const APP_REDIRECT_URI = "custom://oauth_callback";
 
     beforeEach(async () => {
+      await cleanDatabase();
+
       account = await createAccount();
       client = await createOAuthApplication({
         scopes: ["read:accounts"],
@@ -554,10 +554,6 @@ describe.sequential("OAuth", () => {
         confidential: true,
       });
       application = await getApplication(client);
-    });
-
-    afterEach(async () => {
-      await cleanDatabase();
     });
 
     it("Does not create an access grant if denied", async () => {
@@ -716,7 +712,11 @@ describe.sequential("OAuth", () => {
     });
 
     it("returns an error if the application does not exist", async () => {
-      expect.assertions(1);
+      expect.assertions(2);
+
+      // This is an incredibly small chance, but just to make debugging this
+      // failure case somewhat easier to debug:
+      expect(application.id).not.toBe("403dafb4-9c37-4dfc-bfb4-02fb0cf681fb");
 
       const cookie = await getLoginCookie();
       const formData = new FormData();
@@ -827,6 +827,8 @@ describe.sequential("OAuth", () => {
     let client: Awaited<ReturnType<typeof createOAuthApplication>>;
 
     beforeEach(async () => {
+      await cleanDatabase();
+
       account = await createAccount();
       client = await createOAuthApplication({
         scopes: ["read:accounts"],
@@ -834,10 +836,6 @@ describe.sequential("OAuth", () => {
         confidential: true,
       });
       application = await getApplication(client);
-    });
-
-    afterEach(async () => {
-      await cleanDatabase();
     });
 
     it("can exchange an access grant for an access token using PKCE", async () => {
@@ -980,6 +978,8 @@ describe.sequential("OAuth", () => {
     let wrongClient: Awaited<ReturnType<typeof createOAuthApplication>>;
 
     beforeEach(async () => {
+      await cleanDatabase();
+
       account = await createAccount();
       client = await createOAuthApplication({
         scopes: ["read:accounts"],
@@ -994,11 +994,6 @@ describe.sequential("OAuth", () => {
         confidential: true,
       });
       wrongApplication = await getApplication(wrongClient);
-    });
-
-    afterEach(async () => {
-      vi.useRealTimers();
-      await cleanDatabase();
     });
 
     it("cannot request an access token without using a client authentication method", async () => {
@@ -1217,10 +1212,10 @@ describe.sequential("OAuth", () => {
     describe.sequential("expired access grants", () => {
       beforeEach(() => {
         timekeeper.freeze();
-      });
 
-      afterEach(() => {
-        timekeeper.reset();
+        return () => {
+          timekeeper.reset();
+        };
       });
 
       it("cannot exchange an access grant for an access token when the access grant has expired", async () => {
@@ -1404,6 +1399,8 @@ describe.sequential("OAuth", () => {
     let account: Awaited<ReturnType<typeof createAccount>>;
 
     beforeEach(async () => {
+      await cleanDatabase();
+
       account = await createAccount();
       client = await createOAuthApplication({
         scopes: ["read:accounts"],
@@ -1411,10 +1408,6 @@ describe.sequential("OAuth", () => {
         confidential: false,
       });
       application = await getApplication(client);
-    });
-
-    afterEach(async () => {
-      await cleanDatabase();
     });
 
     it("can request an access token using the authorization code grant flow", async () => {

--- a/src/oauth.tsx
+++ b/src/oauth.tsx
@@ -147,7 +147,7 @@ app.post(
     }
 
     const accountOwner = await db.query.accountOwners.findFirst({
-      where: eq(applications.id, form.account_id),
+      where: eq(accountOwners.id, form.account_id),
     });
     if (accountOwner == null) {
       return c.notFound();

--- a/src/oauth.tsx
+++ b/src/oauth.tsx
@@ -4,6 +4,7 @@ import { and, eq } from "drizzle-orm";
 import { type Context, Hono } from "hono";
 import { cors } from "hono/cors";
 import { z } from "zod";
+
 import { db } from "./db.ts";
 import { requestBody } from "./helpers.ts";
 import { loginRequired } from "./login.ts";
@@ -26,6 +27,8 @@ import {
   scopeEnum,
 } from "./schema.ts";
 import { uuid } from "./uuid.ts";
+
+import userInfoEndpoint from "./oauth/endpoints/userinfo.ts";
 
 import { AuthorizationPage } from "./pages/oauth/authorization.tsx";
 import { AuthorizationCodePage } from "./pages/oauth/authorization_code.tsx";
@@ -59,6 +62,8 @@ const validatePKCEParameters = (
     };
   }
 };
+
+app.route("/userinfo", userInfoEndpoint);
 
 app.get(
   "/authorize",

--- a/src/oauth.tsx
+++ b/src/oauth.tsx
@@ -1,8 +1,7 @@
 import { zValidator } from "@hono/zod-validator";
 import { getLogger } from "@logtape/logtape";
-import { and, eq } from "drizzle-orm";
-import { type Context, Hono } from "hono";
-import { cors } from "hono/cors";
+import { eq } from "drizzle-orm";
+import { Hono } from "hono";
 import { z } from "zod";
 
 import { db } from "./db.ts";
@@ -20,14 +19,10 @@ import {
   clientAuthentication,
 } from "./oauth/middleware.ts";
 import { scopesSchema } from "./oauth/validators.ts";
-import {
-  accessGrants,
-  accessTokens,
-  applications,
-  scopeEnum,
-} from "./schema.ts";
+import { accessGrants, accountOwners, applications } from "./schema.ts";
 import { uuid } from "./uuid.ts";
 
+import revokeEndpoint from "./oauth/endpoints/revoke.ts";
 import userInfoEndpoint from "./oauth/endpoints/userinfo.ts";
 
 import { AuthorizationPage } from "./pages/oauth/authorization.tsx";
@@ -64,6 +59,7 @@ const validatePKCEParameters = (
 };
 
 app.route("/userinfo", userInfoEndpoint);
+app.route("/revoke", revokeEndpoint);
 
 app.get(
   "/authorize",
@@ -237,7 +233,7 @@ const tokenRequestSchema = z.discriminatedUnion("grant_type", [
   }),
 ]);
 
-app.post("/token", cors(), clientAuthentication, async (c) => {
+app.post("/token", clientAuthentication, async (c) => {
   const client = c.get("client");
   const result = await requestBody(c.req, tokenRequestSchema);
 
@@ -402,75 +398,5 @@ app.post("/token", cors(), clientAuthentication, async (c) => {
     });
   }
 });
-
-// RFC7009 - OAuth Token Revocation:
-const tokenRevocationSchema = z.strictObject({
-  token: z.string(),
-  token_type_hint: z.string().optional(),
-  // client_id and client_secret are present but consumed by the
-  // clientAuthentication middleware:
-  client_id: z.string().optional(),
-  client_secret: z.string().optional(),
-});
-
-app.post("/revoke", cors(), clientAuthentication, async (c) => {
-  const client = c.get("client");
-  const result = await requestBody(c.req, tokenRevocationSchema);
-
-  if (!result.success) {
-    return c.json({ error: "invalid_request", zod_error: result.error }, 400);
-  }
-
-  if (
-    result.data.token_type_hint &&
-    result.data.token_type_hint !== "access_token"
-  ) {
-    return c.json(
-      {
-        error: "unsupported_token_type",
-        error_description:
-          "The authorization server does not support the revocation of the presented token type",
-      },
-      400,
-    );
-  }
-
-  await db
-    .delete(accessTokens)
-    .where(
-      and(
-        eq(accessTokens.code, result.data.token),
-        eq(accessTokens.applicationId, client.id),
-      ),
-    );
-
-  // The spec is a little strange here in that the response status is 200, but
-  // there's actually no response body, so 204 would be more appropriate.
-  // We return an empty json response to make testing easier:
-  return c.json({}, 200);
-});
-
-export async function oauthAuthorizationServer(c: Context) {
-  const url = new URL(c.req.url);
-
-  return c.json({
-    issuer: new URL("/", url).href,
-    authorization_endpoint: new URL("/oauth/authorize", url).href,
-    token_endpoint: new URL("/oauth/token", url).href,
-    revocation_endpoint: new URL("/oauth/revoke", url).href,
-    scopes_supported: scopeEnum.enumValues,
-    response_types_supported: ["code"],
-    response_modes_supported: ["query"],
-    grant_types_supported: ["authorization_code", "client_credentials"],
-    token_endpoint_auth_methods_supported: [
-      "client_secret_post",
-      "client_secret_basic",
-      // Not supported until we support public clients:
-      // "none",
-    ],
-    code_challenge_methods_supported: ["S256"],
-    app_registration_endpoint: new URL("/api/v1/apps", url).href,
-  });
-}
 
 export default app;

--- a/src/oauth/endpoints/metadata.test.ts
+++ b/src/oauth/endpoints/metadata.test.ts
@@ -10,7 +10,8 @@ describe("GET /.well-known/oauth-authorization-server", () => {
   app.route("/.well-known/oauth-authorization-server", metadataEndpoint);
 
   it("returns OAuth authorization server metadata", async () => {
-    expect.assertions(14);
+    expect.assertions(15);
+
     // We use the full URL in this test as the route calculates values based
     // on the Host header
     const response = await app.request(
@@ -30,6 +31,7 @@ describe("GET /.well-known/oauth-authorization-server", () => {
     );
     expect(json.token_endpoint).toBe("https://hollo.test/oauth/token");
     expect(json.revocation_endpoint).toBe("https://hollo.test/oauth/revoke");
+    expect(json.userinfo_endpoint).toBe("https://hollo.test/oauth/userinfo");
     // Non-standard, mastodon extension:
     expect(json.app_registration_endpoint).toBe(
       "https://hollo.test/api/v1/apps",

--- a/src/oauth/endpoints/metadata.test.ts
+++ b/src/oauth/endpoints/metadata.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { Hono } from "hono";
+
+import * as Schema from "../../schema";
+import metadataEndpoint from "./metadata";
+
+describe("GET /.well-known/oauth-authorization-server", () => {
+  const app = new Hono();
+  app.route("/.well-known/oauth-authorization-server", metadataEndpoint);
+
+  it("returns OAuth authorization server metadata", async () => {
+    expect.assertions(14);
+    // We use the full URL in this test as the route calculates values based
+    // on the Host header
+    const response = await app.request(
+      "https://hollo.test/.well-known/oauth-authorization-server",
+      {
+        method: "GET",
+      },
+    );
+
+    expect(response.status).toBe(200);
+
+    const json = await response.json();
+
+    expect(json.issuer).toBe("https://hollo.test/");
+    expect(json.authorization_endpoint).toBe(
+      "https://hollo.test/oauth/authorize",
+    );
+    expect(json.token_endpoint).toBe("https://hollo.test/oauth/token");
+    expect(json.revocation_endpoint).toBe("https://hollo.test/oauth/revoke");
+    // Non-standard, mastodon extension:
+    expect(json.app_registration_endpoint).toBe(
+      "https://hollo.test/api/v1/apps",
+    );
+
+    expect(json.response_types_supported).toEqual(["code"]);
+    expect(json.response_modes_supported).toEqual(["query"]);
+    expect(json.grant_types_supported).toEqual([
+      "authorization_code",
+      "client_credentials",
+    ]);
+    expect(json.token_endpoint_auth_methods_supported).toEqual([
+      "client_secret_post",
+      "client_secret_basic",
+    ]);
+
+    expect(Array.isArray(json.scopes_supported)).toBeTruthy();
+    expect(json.scopes_supported).toEqual(Schema.scopeEnum.enumValues);
+
+    expect(Array.isArray(json.code_challenge_methods_supported)).toBeTruthy();
+    expect(json.code_challenge_methods_supported).toEqual(["S256"]);
+  });
+});

--- a/src/oauth/endpoints/metadata.ts
+++ b/src/oauth/endpoints/metadata.ts
@@ -11,6 +11,7 @@ app.get("/", (c) => {
     authorization_endpoint: new URL("/oauth/authorize", url).href,
     token_endpoint: new URL("/oauth/token", url).href,
     revocation_endpoint: new URL("/oauth/revoke", url).href,
+    userinfo_endpoint: new URL("/oauth/userinfo", url).href,
     scopes_supported: Schema.scopeEnum.enumValues,
     response_types_supported: ["code"],
     response_modes_supported: ["query"],

--- a/src/oauth/endpoints/metadata.ts
+++ b/src/oauth/endpoints/metadata.ts
@@ -1,0 +1,29 @@
+import { Hono } from "hono";
+import * as Schema from "../../schema";
+
+const app = new Hono();
+
+app.get("/", (c) => {
+  const url = new URL(c.req.url);
+
+  return c.json({
+    issuer: new URL("/", url).href,
+    authorization_endpoint: new URL("/oauth/authorize", url).href,
+    token_endpoint: new URL("/oauth/token", url).href,
+    revocation_endpoint: new URL("/oauth/revoke", url).href,
+    scopes_supported: Schema.scopeEnum.enumValues,
+    response_types_supported: ["code"],
+    response_modes_supported: ["query"],
+    grant_types_supported: ["authorization_code", "client_credentials"],
+    token_endpoint_auth_methods_supported: [
+      "client_secret_post",
+      "client_secret_basic",
+      // Not supported until we support public clients:
+      // "none",
+    ],
+    code_challenge_methods_supported: ["S256"],
+    app_registration_endpoint: new URL("/api/v1/apps", url).href,
+  });
+});
+
+export default app;

--- a/src/oauth/endpoints/revoke.test.ts
+++ b/src/oauth/endpoints/revoke.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Hono } from "hono";
+import { cleanDatabase } from "../../../tests/helpers";
+import {
+  basicAuthorization,
+  createAccount,
+  createOAuthApplication,
+  findAccessToken,
+  getAccessToken,
+  getApplication,
+} from "../../../tests/helpers/oauth";
+
+import type * as Schema from "../../schema";
+
+import { OOB_REDIRECT_URI } from "../constants";
+import revokeEndpoint from "./revoke";
+
+describe.sequential("POST /oauth/revoke", () => {
+  let account: Awaited<ReturnType<typeof createAccount>>;
+  let client: Awaited<ReturnType<typeof createOAuthApplication>>;
+  let application: Schema.Application;
+  let wrongClient: Awaited<ReturnType<typeof createOAuthApplication>>;
+  let wrongApplication: Schema.Application;
+
+  const app = new Hono();
+  app.route("/oauth/revoke", revokeEndpoint);
+
+  beforeEach(async () => {
+    await cleanDatabase();
+
+    account = await createAccount();
+    client = await createOAuthApplication({
+      scopes: ["read:accounts"],
+      redirectUris: [OOB_REDIRECT_URI],
+      confidential: true,
+    });
+    application = await getApplication(client);
+
+    wrongClient = await createOAuthApplication({
+      scopes: ["read:accounts"],
+      redirectUris: [OOB_REDIRECT_URI],
+      confidential: true,
+    });
+    wrongApplication = await getApplication(wrongClient);
+  });
+
+  it("can revoke an access token using client_secret_basic", async () => {
+    expect.assertions(3);
+    const accessToken = await getAccessToken(client, account);
+    const body = new FormData();
+    body.set("token", accessToken.token);
+
+    const response = await app.request("/oauth/revoke", {
+      method: "POST",
+      headers: {
+        authorization: basicAuthorization(application),
+      },
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+
+    const accessTokenAfterRevocation = await findAccessToken(accessToken.token);
+
+    expect(accessTokenAfterRevocation).toBe(undefined);
+  });
+
+  it("can revoke an access token using client_secret_post", async () => {
+    expect.assertions(3);
+    const accessToken = await getAccessToken(client, account);
+    const body = new FormData();
+    body.set("token", accessToken.token);
+    body.set("client_id", application.clientId);
+    body.set("client_secret", application.clientSecret);
+
+    const response = await app.request("/oauth/revoke", {
+      method: "POST",
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+
+    const accessTokenAfterRevocation = await findAccessToken(accessToken.token);
+
+    expect(accessTokenAfterRevocation).toBe(undefined);
+  });
+
+  it("cannot revoke an access token for a different client, but does not return any errors", async () => {
+    expect.assertions(3);
+    const accessToken = await getAccessToken(client, account);
+    const body = new FormData();
+    body.set("token", accessToken.token);
+    body.set("client_id", wrongApplication.clientId);
+    body.set("client_secret", wrongApplication.clientSecret);
+
+    const response = await app.request("/oauth/revoke", {
+      method: "POST",
+      body,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+
+    const accessTokenAfterRevocation = await findAccessToken(accessToken.token);
+
+    expect(accessTokenAfterRevocation).not.toBe(undefined);
+  });
+
+  it("cannot revoke a token using token_type_hint of refresh_token", async () => {
+    expect.assertions(4);
+    const body = new FormData();
+    body.set("token", "123");
+    body.set("token_type_hint", "refresh_token");
+
+    const response = await app.request("/oauth/revoke", {
+      method: "POST",
+      headers: {
+        authorization: basicAuthorization(application),
+      },
+      body,
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("content-type")).toBe("application/json");
+
+    const responseBody = await response.json();
+
+    expect(typeof responseBody).toBe("object");
+    expect(responseBody.error).toBe("unsupported_token_type");
+  });
+
+  it("cannot revoke a token without supplying the token parameter", async () => {
+    expect.assertions(4);
+    const body = new FormData();
+    // explicitly doesn't have `token`
+    body.set("token_type_hint", "refresh_token");
+
+    const response = await app.request("/oauth/revoke", {
+      method: "POST",
+      headers: {
+        authorization: basicAuthorization(application),
+      },
+      body,
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("content-type")).toBe("application/json");
+
+    const responseBody = await response.json();
+
+    expect(typeof responseBody).toBe("object");
+    expect(responseBody.error).toBe("invalid_request");
+  });
+});

--- a/src/oauth/endpoints/revoke.ts
+++ b/src/oauth/endpoints/revoke.ts
@@ -1,0 +1,61 @@
+import { and, eq } from "drizzle-orm";
+import { Hono } from "hono";
+import { z } from "zod";
+import db from "../../db";
+import { requestBody } from "../../helpers";
+import * as Schema from "../../schema";
+import {
+  type ClientAuthenticationVariables,
+  clientAuthentication,
+} from "../middleware";
+
+const app = new Hono<{ Variables: ClientAuthenticationVariables }>();
+
+// RFC7009 - OAuth Token Revocation:
+const tokenRevocationSchema = z.strictObject({
+  token: z.string(),
+  token_type_hint: z.string().optional(),
+  // client_id and client_secret are present but consumed by the
+  // clientAuthentication middleware:
+  client_id: z.string().optional(),
+  client_secret: z.string().optional(),
+});
+
+app.post("/", clientAuthentication, async (c) => {
+  const client = c.get("client");
+  const result = await requestBody(c.req, tokenRevocationSchema);
+
+  if (!result.success) {
+    return c.json({ error: "invalid_request", zod_error: result.error }, 400);
+  }
+
+  if (
+    result.data.token_type_hint &&
+    result.data.token_type_hint !== "access_token"
+  ) {
+    return c.json(
+      {
+        error: "unsupported_token_type",
+        error_description:
+          "The authorization server does not support the revocation of the presented token type",
+      },
+      400,
+    );
+  }
+
+  await db
+    .delete(Schema.accessTokens)
+    .where(
+      and(
+        eq(Schema.accessTokens.code, result.data.token),
+        eq(Schema.accessTokens.applicationId, client.id),
+      ),
+    );
+
+  // The spec is a little strange here in that the response status is 200, but
+  // there's actually no response body, so 204 would be more appropriate.
+  // We return an empty json response to make testing easier:
+  return c.json({}, 200);
+});
+
+export default app;

--- a/src/oauth/endpoints/userinfo.test.ts
+++ b/src/oauth/endpoints/userinfo.test.ts
@@ -63,7 +63,7 @@ describe.sequential("/oauth/userinfo", () => {
 
     expect(json.iss).toBe("https://hollo.test/");
     expect(json.sub).toBe("https://hollo.test/@hollo");
-    expect(json.name).toBe("Hollo Test");
+    expect(json.name).toBe("Test: hollo");
     expect(json.preferredUsername).toBe("hollo");
     expect(json.profile).toBe("https://hollo.test/@hollo");
     expect(json.picture).toBe(
@@ -96,7 +96,7 @@ describe.sequential("/oauth/userinfo", () => {
 
     expect(json.iss).toBe("https://hollo.test/");
     expect(json.sub).toBe("https://hollo.test/@hollo");
-    expect(json.name).toBe("Hollo Test");
+    expect(json.name).toBe("Test: hollo");
     expect(json.preferredUsername).toBe("hollo");
     expect(json.profile).toBe("https://hollo.test/@hollo");
     expect(json.picture).toBe(

--- a/src/oauth/endpoints/userinfo.test.ts
+++ b/src/oauth/endpoints/userinfo.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { Hono } from "hono";
+import { cleanDatabase } from "../../../tests/helpers";
+import {
+  bearerAuthorization,
+  createAccount,
+  createOAuthApplication,
+  getAccessToken,
+  getClientCredentialToken,
+} from "../../../tests/helpers/oauth";
+import userInfoEndpoint from "./userinfo";
+
+describe.sequential("/oauth/userinfo", () => {
+  let client: Awaited<ReturnType<typeof createOAuthApplication>>;
+  let account: Awaited<ReturnType<typeof createAccount>>;
+  let accessToken: Awaited<ReturnType<typeof getAccessToken>>;
+  let invalidToken: Awaited<ReturnType<typeof getAccessToken>>;
+  let clientCredentialToken: Awaited<
+    ReturnType<typeof getClientCredentialToken>
+  >;
+
+  const app = new Hono();
+  app.route("/oauth/userinfo", userInfoEndpoint);
+
+  beforeEach(async () => {
+    await cleanDatabase();
+
+    account = await createAccount();
+    client = await createOAuthApplication({
+      scopes: ["profile", "read"],
+    });
+
+    accessToken = await getAccessToken(client, account, ["profile"]);
+    // wrong scope:
+    invalidToken = await getAccessToken(client, account, ["read"]);
+    // client credential:
+    clientCredentialToken = await getClientCredentialToken(client, ["profile"]);
+  });
+
+  it("can retrieve information about the authenticated user using GET", async () => {
+    // We use the full URL in this test as the route calculates values based
+    // on the Host header
+    const response = await app.request("https://hollo.test/oauth/userinfo", {
+      method: "GET",
+      headers: {
+        authorization: bearerAuthorization(accessToken),
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+
+    const json = await response.json();
+    expect(Object.keys(json)).toEqual([
+      "iss",
+      "sub",
+      "name",
+      "preferredUsername",
+      "profile",
+      "picture",
+    ]);
+
+    expect(json.iss).toBe("https://hollo.test/");
+    expect(json.sub).toBe("https://hollo.test/@hollo");
+    expect(json.name).toBe("Hollo Test");
+    expect(json.preferredUsername).toBe("hollo");
+    expect(json.profile).toBe("https://hollo.test/@hollo");
+    expect(json.picture).toBe(
+      "https://hollo.test/image/avatars/original/missing.png",
+    );
+  });
+
+  it("can retrieve information about the authenticated user using POST", async () => {
+    // We use the full URL in this test as the route calculates values based
+    // on the Host header
+    const response = await app.request("https://hollo.test/oauth/userinfo", {
+      method: "POST",
+      headers: {
+        authorization: bearerAuthorization(accessToken),
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+
+    const json = await response.json();
+    expect(Object.keys(json)).toEqual([
+      "iss",
+      "sub",
+      "name",
+      "preferredUsername",
+      "profile",
+      "picture",
+    ]);
+
+    expect(json.iss).toBe("https://hollo.test/");
+    expect(json.sub).toBe("https://hollo.test/@hollo");
+    expect(json.name).toBe("Hollo Test");
+    expect(json.preferredUsername).toBe("hollo");
+    expect(json.profile).toBe("https://hollo.test/@hollo");
+    expect(json.picture).toBe(
+      "https://hollo.test/image/avatars/original/missing.png",
+    );
+  });
+
+  it("returns an error if the access token doesn't have profile scope", async () => {
+    // We use the full URL in this test as the route calculates values based
+    // on the Host header
+    const response = await app.request("https://hollo.test/oauth/userinfo", {
+      method: "GET",
+      headers: {
+        authorization: bearerAuthorization(invalidToken),
+      },
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.headers.get("content-type")).toBe("application/json");
+
+    const json = await response.json();
+    expect(Object.keys(json)).toEqual(["error"]);
+
+    expect(json.error).toBe("insufficient_scope");
+  });
+
+  it("returns an error if requested without authentication", async () => {
+    // We use the full URL in this test as the route calculates values based
+    // on the Host header
+    const response = await app.request("https://hollo.test/oauth/userinfo", {
+      method: "GET",
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toBe("application/json");
+
+    const json = await response.json();
+    expect(Object.keys(json)).toEqual(["error"]);
+
+    expect(json.error).toBe("unauthorized");
+  });
+
+  it("returns an error if the access token is a client credential", async () => {
+    // We use the full URL in this test as the route calculates values based
+    // on the Host header
+    const response = await app.request("https://hollo.test/oauth/userinfo", {
+      method: "GET",
+      headers: {
+        authorization: bearerAuthorization(clientCredentialToken),
+      },
+    });
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get("content-type")).toBe("application/json");
+
+    const json = await response.json();
+    expect(Object.keys(json)).toEqual(["error"]);
+
+    expect(json.error).toBe("This method requires an authenticated user");
+  });
+});

--- a/src/oauth/endpoints/userinfo.ts
+++ b/src/oauth/endpoints/userinfo.ts
@@ -1,0 +1,33 @@
+import { Hono } from "hono";
+import { type Variables, scopeRequired, tokenRequired } from "../middleware";
+
+const app = new Hono<{ Variables: Variables }>();
+
+app.on(["GET", "POST"], "/", tokenRequired, scopeRequired(["profile"]), (c) => {
+  const accountOwner = c.get("token").accountOwner;
+
+  if (!accountOwner) {
+    return c.json(
+      {
+        error: "This method requires an authenticated user",
+      },
+      401,
+    );
+  }
+
+  const defaultAvatarUrl = new URL(
+    "/image/avatars/original/missing.png",
+    c.req.url,
+  ).href;
+
+  return c.json({
+    iss: new URL("/", c.req.url).href,
+    sub: accountOwner.account.iri,
+    name: accountOwner.account.name,
+    preferredUsername: accountOwner.handle,
+    profile: accountOwner.account.url,
+    picture: accountOwner.account.avatarUrl ?? defaultAvatarUrl,
+  });
+});
+
+export default app;

--- a/src/oauth/middleware.test.ts
+++ b/src/oauth/middleware.test.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import type * as Schema from "../schema";
 
@@ -32,15 +32,13 @@ describe.sequential("OAuth / Middleware", () => {
     let account: Awaited<ReturnType<typeof createAccount>>;
 
     beforeEach(async () => {
+      await cleanDatabase();
+
       account = await createAccount();
       client = await createOAuthApplication({
         scopes: ["read:accounts"],
       });
       application = await getApplication(client);
-    });
-
-    afterEach(async () => {
-      await cleanDatabase();
     });
 
     it("Can use a client credentials token", async () => {
@@ -204,7 +202,7 @@ describe.sequential("OAuth / Middleware", () => {
       });
     });
 
-    afterEach(async () => {
+    beforeEach(async () => {
       await cleanDatabase();
     });
 

--- a/src/pages/emojis.test.ts
+++ b/src/pages/emojis.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import { getFixtureFile } from "../../tests/helpers";
 import { getLoginCookie } from "../../tests/helpers/web";
@@ -14,10 +14,10 @@ const emojiFile = await getFixtureFile("emoji.png", "image/png");
 describe.sequential("emojis", () => {
   beforeEach(async () => {
     await db.delete(customEmojis);
-  });
 
-  afterEach(() => {
-    drive.restore();
+    return () => {
+      drive.restore();
+    };
   });
 
   it("Successfully saves a new emoji", async () => {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -290,6 +290,7 @@ export const scopeEnum = pgEnum("scope", [
   "write:statuses",
   "follow",
   "push",
+  "profile",
 ]);
 
 export type Scope = (typeof scopeEnum.enumValues)[number];

--- a/tests/helpers/oauth.ts
+++ b/tests/helpers/oauth.ts
@@ -43,20 +43,20 @@ export async function createAccount(
       await tx
         .insert(Schema.instances)
         .values({
-          host: "http://hollo.test",
+          host: "hollo.test",
           software: "hollo",
           softwareVersion: null,
         })
         .onConflictDoNothing();
 
       const accountId = crypto.randomUUID();
-      const accountIri = `http://hollo.test/@${username}`;
+      const accountIri = `https://hollo.test/@${username}`;
       const accountUrl = `https://hollo.test/@${username}`;
 
       await tx.insert(Schema.accounts).values({
         id: accountId,
         iri: accountIri,
-        instanceHost: "http://hollo.test",
+        instanceHost: "hollo.test",
         type: "Person",
         name: `Test: ${username}`,
         emojis: {},


### PR DESCRIPTION
This changeset implements #45, whilst doing this, I liked the pattern of `src/oauth/endpoints/*.ts` so decided to also refactor oauth authorization server metadata and `/oauth/revoke` out into similar files, as the tests where just getting too long otherwise.

I also added test coverage for the CORS policy in the index file, since that wasn't previously being asserted yet is actually really important. (also removed some spurious `cors()` calls in oauth, when the policy comes from `index.ts`.

And yeah, I discovered a [heisenbug](https://en.wikipedia.org/wiki/Heisenbug) whilst doing all this, where the tests would randomly fail under some conditions (I'm not sure if I'm correct as to when)

This change *will* conflict with #155, but that's okay, I'll rebase this after #155 is merged.