### PR TITLE
Simplify request body json detection

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -7,10 +7,10 @@ export async function requestBody<T extends z.ZodType = z.ZodTypeAny>(
   schema: T,
   // biome-ignore lint/suspicious/noExplicitAny: Input type is `any` as it comes from the request
 ): Promise<z.SafeParseReturnType<any, z.output<T>>> {
-  const contentType = req.header("Content-Type");
+  const contentType = req.header("Content-Type")?.toLowerCase();
   if (
     contentType === "application/json" ||
-    contentType?.match(/^application\/json\s*;/)
+    contentType?.startsWith("application/json")
   ) {
     const json = await req.json();
     return await schema.safeParseAsync(json);


### PR DESCRIPTION
This avoids the regex by just doing a `startsWith` check, which would do effectively the same thing.