### PR TITLE
Make few status endpoints publicly accessible

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,12 @@ To be released.
     with the `GET /api/v1/accounts/verify_credentials` endpoint.
     [[#45], [#156] by Emelia Smith]
 
+ -  Made few Mastodon API endpoints publicly accessible without
+    authentication so that they behave more similarly to Mastodon:
+
+     -  `GET /api/v1/statuses/:id`
+     -  `GET /api/v1/statuses/:id/context`
+
  -  Upgraded Fedify to 1.5.3 and *@fedify/postgres* to 0.3.0.
 
  -  The minimum required version of Node.js is now 24.0.0.

--- a/src/api/v1/statuses.ts
+++ b/src/api/v1/statuses.ts
@@ -378,7 +378,7 @@ app.put(
 );
 
 app.get("/:id", async (c) => {
-  const token = await getAccessToken(db, c);
+  const token = await getAccessToken(c);
   const owner = token?.scopes.includes("read:statuses")
     ? token?.accountOwner
     : null;
@@ -469,7 +469,7 @@ app.get(
 );
 
 app.get("/:id/context", async (c) => {
-  const token = await getAccessToken(db, c);
+  const token = await getAccessToken(c);
   const owner = token?.scopes.includes("read:statuses")
     ? token?.accountOwner
     : null;

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,7 +1,7 @@
 import { getLogger } from "@logtape/logtape";
 import type { ExtractTablesWithRelations } from "drizzle-orm";
 import type { Logger } from "drizzle-orm/logger";
-import type { PgTransaction } from "drizzle-orm/pg-core";
+import type { PgDatabase, PgTransaction } from "drizzle-orm/pg-core";
 import {
   type PostgresJsQueryResultHKT,
   drizzle,
@@ -66,6 +66,12 @@ export const postgres = createPostgres(databaseUrl, {
   connection: { IntervalStyle: "iso_8601" },
 });
 export const db = drizzle(postgres, { schema, logger: new LogTapeLogger() });
+
+export type Database = PgDatabase<
+  PostgresJsQueryResultHKT,
+  typeof schema,
+  ExtractTablesWithRelations<typeof schema>
+>;
 
 // This is necessary for passing a transaction into a function:
 export type Transaction = PgTransaction<

--- a/src/entities/emoji.ts
+++ b/src/entities/emoji.ts
@@ -23,7 +23,7 @@ export function serializeEmoji(
 
 export function serializeReaction(
   reaction: Reaction & { account: Account },
-  currentAccountOwner: { id: string },
+  currentAccountOwner: { id: string } | undefined | null,
 ): Record<string, unknown> {
   const [result] = serializeReactions([reaction], currentAccountOwner);
   return result;
@@ -31,7 +31,7 @@ export function serializeReaction(
 
 export function serializeReactions(
   reactions: (Reaction & { account: Account })[],
-  currentAccountOwner: { id: string },
+  currentAccountOwner: { id: string } | undefined | null,
 ): Record<string, unknown>[] {
   const result: Record<
     string,
@@ -49,7 +49,9 @@ export function serializeReactions(
       reaction.customEmoji == null
         ? reaction.emoji
         : `${reaction.emoji}\n${domain}`;
-    const me = reaction.account.id === currentAccountOwner.id;
+    const me =
+      currentAccountOwner != null &&
+      reaction.account.id === currentAccountOwner.id;
     if (key in result) {
       result[key].count++;
       result[key].me ||= me;

--- a/src/entities/poll.ts
+++ b/src/entities/poll.ts
@@ -5,7 +5,7 @@ export function serializePoll(
     options: PollOption[];
     votes: PollVote[];
   },
-  currentAccountOwner: { id: string },
+  currentAccountOwner: { id: string } | undefined | null,
   // biome-ignore lint/suspicious/noExplicitAny: JSON
 ): Record<string, any> {
   return {
@@ -18,10 +18,15 @@ export function serializePoll(
       0,
     ),
     voters_count: poll.multiple ? poll.votersCount : null,
-    voted: poll.votes.some((v) => v.accountId === currentAccountOwner.id),
-    own_votes: poll.votes
-      .filter((v) => v.accountId === currentAccountOwner.id)
-      .map((v) => v.optionIndex),
+    voted:
+      currentAccountOwner != null &&
+      poll.votes.some((v) => v.accountId === currentAccountOwner.id),
+    own_votes:
+      currentAccountOwner == null
+        ? []
+        : poll.votes
+            .filter((v) => v.accountId === currentAccountOwner.id)
+            .map((v) => v.optionIndex),
     options: poll.options
       .toSorted((a, b) => (a.index < b.index ? -1 : 1))
       .map(serializePollOption),

--- a/src/entities/status.ts
+++ b/src/entities/status.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import type { PreviewCard } from "../previewcard";
 import {
   type Account,
@@ -26,7 +26,7 @@ import { serializeEmojis, serializeReactions } from "./emoji";
 import { serializeMedium } from "./medium";
 import { serializePoll } from "./poll";
 
-export function getPostRelations(ownerId: Uuid) {
+export function getPostRelations(ownerId: Uuid | undefined | null) {
   return {
     account: { with: { owner: true, successor: true } },
     application: true,
@@ -45,16 +45,32 @@ export function getPostRelations(ownerId: Uuid) {
             poll: {
               with: {
                 options: { orderBy: pollOptions.index },
-                votes: { where: eq(pollVotes.accountId, ownerId) },
+                votes: {
+                  where:
+                    ownerId == null
+                      ? sql`false`
+                      : eq(pollVotes.accountId, ownerId),
+                },
               },
             },
             mentions: {
               with: { account: { with: { owner: true, successor: true } } },
             },
-            likes: { where: eq(likes.accountId, ownerId) },
+            likes: {
+              where:
+                ownerId == null ? sql`false` : eq(likes.accountId, ownerId),
+            },
             reactions: { with: { account: { with: { successor: true } } } },
-            shares: { where: eq(posts.accountId, ownerId) },
-            bookmarks: { where: eq(bookmarks.accountOwnerId, ownerId) },
+            shares: {
+              where:
+                ownerId == null ? sql`false` : eq(posts.accountId, ownerId),
+            },
+            bookmarks: {
+              where:
+                ownerId == null
+                  ? sql`false`
+                  : eq(bookmarks.accountOwnerId, ownerId),
+            },
             pin: true,
           },
         },
@@ -62,16 +78,28 @@ export function getPostRelations(ownerId: Uuid) {
         poll: {
           with: {
             options: { orderBy: pollOptions.index },
-            votes: { where: eq(pollVotes.accountId, ownerId) },
+            votes: {
+              where:
+                ownerId == null ? sql`false` : eq(pollVotes.accountId, ownerId),
+            },
           },
         },
         mentions: {
           with: { account: { with: { owner: true, successor: true } } },
         },
-        likes: { where: eq(likes.accountId, ownerId) },
+        likes: {
+          where: ownerId == null ? sql`false` : eq(likes.accountId, ownerId),
+        },
         reactions: { with: { account: { with: { successor: true } } } },
-        shares: { where: eq(posts.accountId, ownerId) },
-        bookmarks: { where: eq(bookmarks.accountOwnerId, ownerId) },
+        shares: {
+          where: ownerId == null ? sql`false` : eq(posts.accountId, ownerId),
+        },
+        bookmarks: {
+          where:
+            ownerId == null
+              ? sql`false`
+              : eq(bookmarks.accountOwnerId, ownerId),
+        },
         pin: true,
       },
     },
@@ -84,16 +112,28 @@ export function getPostRelations(ownerId: Uuid) {
         poll: {
           with: {
             options: { orderBy: pollOptions.index },
-            votes: { where: eq(pollVotes.accountId, ownerId) },
+            votes: {
+              where:
+                ownerId == null ? sql`false` : eq(pollVotes.accountId, ownerId),
+            },
           },
         },
         mentions: {
           with: { account: { with: { owner: true, successor: true } } },
         },
-        likes: { where: eq(likes.accountId, ownerId) },
+        likes: {
+          where: ownerId == null ? sql`false` : eq(likes.accountId, ownerId),
+        },
         reactions: { with: { account: { with: { successor: true } } } },
-        shares: { where: eq(posts.accountId, ownerId) },
-        bookmarks: { where: eq(bookmarks.accountOwnerId, ownerId) },
+        shares: {
+          where: ownerId == null ? sql`false` : eq(posts.accountId, ownerId),
+        },
+        bookmarks: {
+          where:
+            ownerId == null
+              ? sql`false`
+              : eq(bookmarks.accountOwnerId, ownerId),
+        },
         pin: true,
       },
     },
@@ -101,14 +141,24 @@ export function getPostRelations(ownerId: Uuid) {
     poll: {
       with: {
         options: { orderBy: pollOptions.index },
-        votes: { where: eq(pollVotes.accountId, ownerId) },
+        votes: {
+          where:
+            ownerId == null ? sql`false` : eq(pollVotes.accountId, ownerId),
+        },
       },
     },
     mentions: { with: { account: { with: { owner: true, successor: true } } } },
-    likes: { where: eq(likes.accountId, ownerId) },
+    likes: {
+      where: ownerId == null ? sql`false` : eq(likes.accountId, ownerId),
+    },
     reactions: { with: { account: { with: { successor: true } } } },
-    shares: { where: eq(posts.accountId, ownerId) },
-    bookmarks: { where: eq(bookmarks.accountOwnerId, ownerId) },
+    shares: {
+      where: ownerId == null ? sql`false` : eq(posts.accountId, ownerId),
+    },
+    bookmarks: {
+      where:
+        ownerId == null ? sql`false` : eq(bookmarks.accountOwnerId, ownerId),
+    },
     pin: true,
     replies: true,
   } as const;
@@ -203,7 +253,7 @@ export function serializePost(
     bookmarks: Bookmark[];
     pin: PinnedPost | null;
   },
-  currentAccountOwner: { id: string },
+  currentAccountOwner: { id: string } | undefined | null,
   baseUrl: URL | string,
   // biome-ignore lint/suspicious/noExplicitAny: JSON
 ): Record<string, any> {
@@ -221,17 +271,27 @@ export function serializePost(
     replies_count: post.repliesCount ?? 0,
     reblogs_count: post.sharesCount ?? 0,
     favourites_count: post.likesCount ?? 0,
-    favourited: post.likes.some(
-      (like) => like.accountId === currentAccountOwner.id,
-    ),
-    reblogged: post.shares.some(
-      (share) => share.accountId === currentAccountOwner.id,
-    ),
+    favourited:
+      currentAccountOwner == null
+        ? false
+        : post.likes.some((like) => like.accountId === currentAccountOwner.id),
+    reblogged:
+      currentAccountOwner == null
+        ? false
+        : post.shares.some(
+            (share) => share.accountId === currentAccountOwner.id,
+          ),
     muted: false, // TODO
-    bookmarked: post.bookmarks.some(
-      (bookmark) => bookmark.accountOwnerId === currentAccountOwner.id,
-    ),
-    pinned: post.pin != null && post.pin.accountId === currentAccountOwner.id,
+    bookmarked:
+      currentAccountOwner == null
+        ? false
+        : post.bookmarks.some(
+            (bookmark) => bookmark.accountOwnerId === currentAccountOwner.id,
+          ),
+    pinned:
+      currentAccountOwner == null
+        ? false
+        : post.pin != null && post.pin.accountId === currentAccountOwner.id,
     content: post.contentHtml ?? "",
     reblog:
       post.sharing == null

--- a/src/oauth/helpers.test.ts
+++ b/src/oauth/helpers.test.ts
@@ -88,7 +88,7 @@ describe("OAuth Helpers", () => {
     let retrievedAccessToken: schema.AccessToken | null | undefined;
     const app = new Hono();
     app.get("/", async (c) => {
-      retrievedAccessToken = await getAccessToken(db, c);
+      retrievedAccessToken = await getAccessToken(c);
       return c.json(null);
     });
 

--- a/src/oauth/helpers.ts
+++ b/src/oauth/helpers.ts
@@ -1,7 +1,7 @@
 import { getLogger } from "@logtape/logtape";
 import { eq, lt } from "drizzle-orm";
 import type { Context, Env, HonoRequest } from "hono";
-import db, { type Database, type Transaction } from "../db";
+import db, { type Transaction } from "../db";
 import { base64Url, randomBytes } from "../helpers";
 import * as schema from "../schema";
 import type { Uuid } from "../uuid";
@@ -176,14 +176,12 @@ export async function createClientCredential(
 
 /**
  * Retrieves an access token from the request's `Authorization` header.
- * @param db The database instance to query for the access token.
  * @param c The Hono request context or request object containing
  *          the `Authorization` header.
  * @returns The access token if found, or `undefined` if the header is missing
  *          or malformed, or `null` if the token does not exist in the database.
  */
 export async function getAccessToken<T extends Env>(
-  db: Database,
   c: Context<T> | HonoRequest,
 ): Promise<
   | (schema.AccessToken & {

--- a/src/oauth/middleware.ts
+++ b/src/oauth/middleware.ts
@@ -149,7 +149,7 @@ export const clientAuthentication = createMiddleware<{
 
 export const tokenRequired = createMiddleware<{ Variables: Variables }>(
   async (c, next) => {
-    const accessToken = await getAccessToken(db, c);
+    const accessToken = await getAccessToken(c);
     if (typeof accessToken === "undefined") {
       return c.json({ error: "unauthorized" }, 401);
     }


### PR DESCRIPTION
Allow unauthenticated access to [`GET /api/v1/statuses/:id`](https://docs.joinmastodon.org/methods/statuses/#get) and [`GET /api/v1/statuses/:id/context`](https://docs.joinmastodon.org/methods/statuses/#context) endpoints for public/unlisted posts. This improves compatibility with some Mastodon clients including Phanpy.

Context: <https://mastodon.social/@cheeaun/114624168179399377>.