### PR TITLE
fix(api): Accept null values for optional fields in /api/v1/statuses endpoin

### DIFF
--- a/src/api/v1/statuses.test.ts
+++ b/src/api/v1/statuses.test.ts
@@ -201,4 +201,44 @@ describe.sequential("/api/v1/accounts/verify_credentials", () => {
     expect(json.account.id).toBe(account.id);
     expect(json.language).toBe("en");
   });
+
+  it("Null values are replaced with appropriate defaults", async () => {
+    expect.assertions(10);
+
+    // Send a request with nulls
+    const body = JSON.stringify({
+      status: "Testing defaults",
+      visibility: null,
+      in_reply_to_id: null,
+      spoiler_text: null,
+      media_ids: null,
+      poll: null,
+      language: null,
+    });
+
+    const response = await app.request("/api/v1/statuses", {
+      method: "POST",
+      headers: {
+        authorization: bearerAuthorization(accessToken),
+        "Content-Type": "application/json",
+      },
+      body: body,
+    });
+
+    expect(response.status).toBe(200);
+
+    const json = await response.json();
+
+    expect(json.visibility).not.toBeNull();
+    expect(json.visibility).toBe("public");
+    expect(json.in_reply_to_id).toBeNull();
+
+    expect(json.spoiler_text).toBe("");
+    expect(json.media_attachments).toEqual([]);
+    expect(json.poll).toBeNull();
+
+    expect(json.sensitive).toBe(false);
+    expect(json.language).not.toBeNull();
+    expect(json.content).toBe("<p>Testing defaults</p>\n");
+  });
 });

--- a/src/api/v1/statuses.test.ts
+++ b/src/api/v1/statuses.test.ts
@@ -170,16 +170,15 @@ describe.sequential("/api/v1/accounts/verify_credentials", () => {
     expect(updateJson.content).toBe("<p>Test Update</p>\n");
   });
 
-  it("Issue 177: successfully creates a status with null values for optional fields", async () => {
-    expect.assertions(6);
+  it("Issue 177: successfully creates a status with null values, setting appropriate defaults", async () => {
     const body = JSON.stringify({
-      language: "en",
+      language: null,
       status: "Awoo!",
       in_reply_to_id: null,
       sensitive: false,
       spoiler_text: null,
       media_ids: null,
-      visibility: "public",
+      visibility: null,
       poll: null,
     });
 
@@ -197,48 +196,18 @@ describe.sequential("/api/v1/accounts/verify_credentials", () => {
 
     const json = await response.json();
     expect(typeof json).toBe("object");
+
+    // Basic creation success
     expect(json.content).toBe("<p>Awoo!</p>\n");
     expect(json.account.id).toBe(account.id);
-    expect(json.language).toBe("en");
-  });
 
-  it("Null values are replaced with appropriate defaults", async () => {
-    expect.assertions(10);
-
-    // Send a request with nulls
-    const body = JSON.stringify({
-      status: "Testing defaults",
-      visibility: null,
-      in_reply_to_id: null,
-      spoiler_text: null,
-      media_ids: null,
-      poll: null,
-      language: null,
-    });
-
-    const response = await app.request("/api/v1/statuses", {
-      method: "POST",
-      headers: {
-        authorization: bearerAuthorization(accessToken),
-        "Content-Type": "application/json",
-      },
-      body: body,
-    });
-
-    expect(response.status).toBe(200);
-
-    const json = await response.json();
-
+    // Verify null values are replaced with appropriate defaults
     expect(json.visibility).not.toBeNull();
     expect(json.visibility).toBe("public");
-    expect(json.in_reply_to_id).toBeNull();
-
     expect(json.spoiler_text).toBe("");
     expect(json.media_attachments).toEqual([]);
-    expect(json.poll).toBeNull();
-
     expect(json.sensitive).toBe(false);
     expect(json.language).not.toBeNull();
-    expect(json.content).toBe("<p>Testing defaults</p>\n");
+    expect(json.poll).toBeNull(); // This one stays null as expected
   });
 });

--- a/src/api/v1/statuses.test.ts
+++ b/src/api/v1/statuses.test.ts
@@ -169,4 +169,36 @@ describe.sequential("/api/v1/accounts/verify_credentials", () => {
     expect(typeof updateJson).toBe("object");
     expect(updateJson.content).toBe("<p>Test Update</p>\n");
   });
+
+  it("Issue 177: successfully creates a status with null values for optional fields", async () => {
+    expect.assertions(6);
+    const body = JSON.stringify({
+      language: "en",
+      status: "Awoo!",
+      in_reply_to_id: null,
+      sensitive: false,
+      spoiler_text: null,
+      media_ids: null,
+      visibility: "public",
+      poll: null,
+    });
+
+    const response = await app.request("/api/v1/statuses", {
+      method: "POST",
+      headers: {
+        authorization: bearerAuthorization(accessToken),
+        "Content-Type": "application/json",
+      },
+      body: body,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("application/json");
+
+    const json = await response.json();
+    expect(typeof json).toBe("object");
+    expect(json.content).toBe("<p>Awoo!</p>\n");
+    expect(json.account.id).toBe(account.id);
+    expect(json.language).toBe("en");
+  });
 });

--- a/src/api/v1/statuses.ts
+++ b/src/api/v1/statuses.ts
@@ -160,8 +160,8 @@ function buildMuteAndBlockConditions(viewerAccountId: Uuid | null | undefined) {
 }
 
 const statusSchema = z.object({
-  status: z.string().min(1).optional(),
-  media_ids: z.array(uuid).optional(),
+  status: z.string().min(1).optional().nullable(),
+  media_ids: z.array(uuid).optional().nullable(),
   poll: z
     .object({
       options: z.array(z.string()),
@@ -175,18 +175,22 @@ const statusSchema = z.object({
       multiple: z.boolean().default(false),
       hide_totals: z.boolean().default(false),
     })
-    .optional(),
+    .optional()
+    .nullable(),
   sensitive: z.boolean().default(false),
-  spoiler_text: z.string().optional(),
-  language: z.string().min(2).optional(),
+  spoiler_text: z.string().optional().nullable(),
+  language: z.string().min(2).optional().nullable(),
 });
 
 const createStatusSchema = statusSchema.merge(
   z.object({
-    in_reply_to_id: uuid.optional(),
-    quote_id: uuid.optional(),
-    visibility: z.enum(["public", "unlisted", "private", "direct"]).optional(),
-    scheduled_at: z.string().datetime().optional(),
+    in_reply_to_id: uuid.optional().nullable(),
+    quote_id: uuid.optional().nullable(),
+    visibility: z
+      .enum(["public", "unlisted", "private", "direct"])
+      .optional()
+      .nullable(),
+    scheduled_at: z.string().datetime().optional().nullable(),
   }),
 );
 

--- a/src/text.ts
+++ b/src/text.ts
@@ -272,7 +272,7 @@ export async function formatPostContent(
     ExtractTablesWithRelations<typeof schema>
   >,
   text: string,
-  language: string | undefined,
+  language: string | null | undefined,
   options: {
     url: URL | string;
     contextLoader?: DocumentLoader;


### PR DESCRIPTION
# Description
fixes #177

- Updated the schemas to explicitly accept null values using .nullable() for all optional fields:
  - status, media_ids, poll, spoiler_text, language in statusSchema
  - in_reply_to_id, quote_id, visibility, scheduled_at in createStatusSchema

- Updated the formatPostContent function to accept null values