### PR TITLE
fix new date check in query to be ANDed to existing checks and not ORed

### DIFF
--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -77,9 +77,8 @@ app.get(
     const statuses =
       query.offset < 1
         ? await db.query.posts.findMany({
-            where: or(
-              eq(posts.iri, q),
-              eq(posts.url, q),
+            where: and(
+              or(eq(posts.iri, q), eq(posts.url, q)),
               lte(posts.published, sql`NOW() + INTERVAL '5 minutes'`),
             ),
             with: getPostRelations(owner.id),


### PR DESCRIPTION
Because the new check was ORed and not ANDed, the query would return too many items, this caused issues.
Tested on my instance as fixing the problem I've been having in v0.6.7 where searches time out.