### PR TITLE
Fix direct message visibility filtering in status queries

### DIFF
--- a/src/api/v1/statuses.ts
+++ b/src/api/v1/statuses.ts
@@ -80,7 +80,8 @@ const app = new Hono<{ Variables: Variables }>();
 /**
  * Builds visibility conditions for post queries based on viewer's permissions.
  * For unauthenticated users, only public/unlisted posts are visible.
- * For authenticated users, includes private posts from accounts they follow.
+ * For authenticated users, includes private posts from accounts they follow,
+ * and direct posts where they are mentioned or are the author.
  */
 function buildVisibilityConditions(viewerAccountId: Uuid | null | undefined) {
   if (viewerAccountId == null) {
@@ -88,9 +89,9 @@ function buildVisibilityConditions(viewerAccountId: Uuid | null | undefined) {
     return inArray(posts.visibility, ["public", "unlisted"]);
   }
 
-  // Authenticated: include private posts based on follower relationships
+  // Authenticated: include private and direct posts based on relationships
   return or(
-    inArray(posts.visibility, ["public", "unlisted", "direct"]),
+    inArray(posts.visibility, ["public", "unlisted"]),
     and(
       eq(posts.visibility, "private"),
       or(
@@ -111,12 +112,24 @@ function buildVisibilityConditions(viewerAccountId: Uuid | null | undefined) {
         ),
       ),
     ),
-    // Also include posts that mention the viewer
-    exists(
-      db
-        .select({ id: mentions.postId })
-        .from(mentions)
-        .where(eq(mentions.accountId, viewerAccountId)),
+    and(
+      eq(posts.visibility, "direct"),
+      or(
+        // User's own direct posts
+        eq(posts.accountId, viewerAccountId),
+        // Direct posts where the user is mentioned
+        exists(
+          db
+            .select({ postId: mentions.postId })
+            .from(mentions)
+            .where(
+              and(
+                eq(mentions.postId, posts.id),
+                eq(mentions.accountId, viewerAccountId),
+              ),
+            ),
+        ),
+      ),
     ),
   );
 }


### PR DESCRIPTION
## Summary

Fixed direct message (DM) visibility filtering to properly restrict access to only authorized users. Previously, direct messages were visible to all authenticated users regardless of whether they were participants in the conversation.

## Related Issue

- fixes #247

## Changes
- Updated buildVisibilityConditions() function in `src/api/v1/statuses.ts` to implement proper direct message access control
- Removed direct messages from the general visibility array and added a separate visibility condition specifically for direct posts

## Benefits
- Prevents unauthorized users from seeing private direct message conversations